### PR TITLE
Fix BOOTIME error

### DIFF
--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -10,6 +10,7 @@ import pycubed_rfm9x
 import board
 import microcontroller
 import busio
+import time
 import digitalio
 import analogio
 import storage
@@ -55,7 +56,7 @@ class Satellite:
     def __init__(self):
         """ Big init routine as the whole board is brought up. """
         self._stat = {}
-        self.BOOTTIME = const(self.timeon)
+        self.BOOTTIME = const(int(time.monotonic()))
         self.hardware = {
             'I2C1': False,
             'I2C2': False,


### PR DESCRIPTION
Importing the pycubed library causes a crash without this fix.