### PR TITLE
Remove extraneous files after build

### DIFF
--- a/state_machine/build.sh
+++ b/state_machine/build.sh
@@ -13,4 +13,8 @@ dot -Tsvg graph.dot > ../output/state_machine.svg
 convert -density 600 ../output/state_machine.svg ../output/state_machine.png
 rm chart.py
 rm graph.dot
+
+# extraneous file removal
+find . -type d -name __pycache__ -exec rm -r {} \+
+rm README.md
 cd - 


### PR DESCRIPTION
__pycache__ files generated after running unit tests add to the file size of the builds, while not achieving anything.
Removing the README as well.