### PR TITLE
Add quaternion mul/quaternion to rotation matrix tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E302, E241, E221, W504
+ignore = E302, E241, E221, W504, E402
 max-line-length = 120
 exclude = *.png, *.md, *.cfg, *.yml, *.sh, *.json, .gitignore, *.txt

--- a/state_machine/unit_tests/test_detumble.py
+++ b/state_machine/unit_tests/test_detumble.py
@@ -5,7 +5,7 @@ from numpy import testing
 sys.path.insert(0, './state_machine/applications/flight')
 sys.path.insert(0, './state_machine/frame')
 
-from Tasks.detumble import bcross  # noqa: E402
+from Tasks.detumble import bcross
 
 
 class MiscTests(unittest.TestCase):

--- a/state_machine/unit_tests/test_mathutils.py
+++ b/state_machine/unit_tests/test_mathutils.py
@@ -4,7 +4,7 @@ from numpy import testing, array, zeros, eye, ones
 
 sys.path.insert(0, './state_machine/applications/flight')
 
-from lib.mathutils import hat, quaternion_to_left_matrix, block  # noqa: E402
+from lib.mathutils import hat, quaternion_to_left_matrix, block, quaternion_to_rotation_matrix, quaternion_mul  # noqa: E402
 
 def col(arr):
     return array([arr]).transpose()
@@ -34,7 +34,7 @@ class HatTests(unittest.TestCase):
             hat(array([[0.7083212680159963, 0.2543322132742208, -0.3982060297895143]]).transpose())
         )
 
-class blockTests(unittest.TestCase):
+class BlockTests(unittest.TestCase):
 
     def test(self):
         a = array([[1, 1]])
@@ -96,4 +96,42 @@ class QuaternionToLeftTests(unittest.TestCase):
                    [-0.398206, -0.254332, 0.708321, -0.524431]]),
             quaternion_to_left_matrix(q),
             decimal=6
+        )
+
+class QuaternionToRotationMatrixTest(unittest.TestCase):
+
+    def test(self):
+        # Using: https://www.andre-gaschler.com/rotationconverter/ to generate test cases
+        # Test cases switched to scalar first (rather than the converter's scalar last)
+        q1 = col([0.6804138, 0.4082483, 0.5443311, 0.2721655])
+        testing.assert_almost_equal(
+            array([[0.2592593,  0.0740741,  0.9629630],
+                   [0.8148148,  0.5185185, -0.2592593],
+                   [-0.5185185,  0.8518519,  0.0740741]]),
+            quaternion_to_rotation_matrix(q1)
+        )
+        q2 = col([0.1601282, 0.3202563, 0.8006408, 0.4803845])
+        testing.assert_almost_equal(
+            array([[-0.7435898,  0.3589744,  0.5641026],
+                   [0.6666667,  0.3333333,  0.6666667],
+                   [0.0512821,  0.8717949, -0.4871795]]),
+            quaternion_to_rotation_matrix(q2)
+        )
+        # identity
+        qi = col([1, 0, 0, 0])
+        testing.assert_almost_equal(
+            eye(3),
+            quaternion_to_rotation_matrix(qi)
+        )
+
+
+class QuaternionMultiplicationTest(unittest.TestCase):
+
+    def test(self):
+        q1 = col([0.6804138, 0.4082483, 0.5443311, 0.2721655])
+        q2 = col([0.1601282, 0.3202563, 0.8006408, 0.4803845])
+        testing.assert_almost_equal(
+            col([-0.58835, 0.32686, 0.52298, 0.52298]),
+            quaternion_mul(q1, q2),
+            decimal=5
         )

--- a/state_machine/unit_tests/test_mathutils.py
+++ b/state_machine/unit_tests/test_mathutils.py
@@ -4,7 +4,7 @@ from numpy import testing, array, zeros, eye, ones
 
 sys.path.insert(0, './state_machine/applications/flight')
 
-from lib.mathutils import hat, quaternion_to_left_matrix, block, quaternion_to_rotation_matrix, quaternion_mul  # noqa: E402
+from lib.mathutils import hat, quaternion_to_left_matrix, block, quaternion_to_rotation_matrix, quaternion_mul
 
 def col(arr):
     return array([arr]).transpose()

--- a/state_machine/unit_tests/test_mekf.py
+++ b/state_machine/unit_tests/test_mekf.py
@@ -4,7 +4,7 @@ from numpy import testing, array, eye
 
 sys.path.insert(0, './state_machine/applications/flight')
 
-import lib.mekf as mekf  # noqa: E402
+import lib.mekf as mekf
 
 def col(arr):
     return array([arr]).transpose()

--- a/state_machine/unit_tests/test_state_machine.py
+++ b/state_machine/unit_tests/test_state_machine.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, './state_machine/frame')
 
-from lib.state_machine_utils import validate_config  # noqa: E402
+from lib.state_machine_utils import validate_config
 
 basicTM = {
     't1': True,


### PR DESCRIPTION
Adds unit tests for functions in the MEKF left uncovered