### PR TITLE
Send status in beacon + untangle code

### DIFF
--- a/state_machine/applications/example/Tasks/battery_task.py
+++ b/state_machine/applications/example/Tasks/battery_task.py
@@ -1,7 +1,7 @@
 # check for low battery condition
 
 from lib.template_task import Task
-import lib.pycubed as cubesat
+from lib.pycubed import cubesat
 
 
 class task(Task):
@@ -12,4 +12,4 @@ class task(Task):
 
     async def main_task(self):
         # Tasks have access to the cubesat object, and can get readings like battery voltage
-        self.debug(f'Current battery voltage: {cubesat.battery_voltage()}')
+        self.debug(f'Current battery voltage: {cubesat.battery_voltage}')

--- a/state_machine/applications/example/Tasks/time_task.py
+++ b/state_machine/applications/example/Tasks/time_task.py
@@ -1,7 +1,7 @@
 # print the time in seconds since boot every 20 seconds
 
 from lib.template_task import Task
-import lib.pycubed as cubesat
+from lib.pycubed import cubesat
 import time
 
 

--- a/state_machine/applications/example/Tasks/transition_task.py
+++ b/state_machine/applications/example/Tasks/transition_task.py
@@ -1,5 +1,5 @@
 from lib.template_task import Task
-import lib.pycubed as cubesat
+from state_machine import state_machine
 
 
 class task(Task):
@@ -7,9 +7,9 @@ class task(Task):
     color = 'blue'
 
     async def main_task(self):
-        if cubesat.state_machine.state == 'Normal':
+        if state_machine.state == 'Normal':
             self.debug('Switching to Special mode')
-            cubesat.state_machine.switch_to('Special')
+            state_machine.switch_to('Special')
         else:
             self.debug('Switching to Normal mode')
-            cubesat.state_machine.switch_to('Normal')
+            state_machine.switch_to('Normal')

--- a/state_machine/applications/flight/Tasks/beacon_task.py
+++ b/state_machine/applications/flight/Tasks/beacon_task.py
@@ -61,4 +61,8 @@ class task(Task):
         print(f'Acceleration: {acc}')
         print(f'Magnetic: {mag}')
         print(f'State: {cubesat.state_machine.state}')
-        return struct.pack("f" * 11, cpu_temp, imu_temp, gyro[0], gyro[1], gyro[2], acc[0], acc[1], acc[2], mag[0], mag[1], mag[2])
+        return struct.pack("f" * 11,
+                           cpu_temp, imu_temp,
+                           gyro[0], gyro[1], gyro[2],
+                           acc[0], acc[1], acc[2],
+                           mag[0], mag[1], mag[2])

--- a/state_machine/applications/flight/Tasks/beacon_task.py
+++ b/state_machine/applications/flight/Tasks/beacon_task.py
@@ -5,6 +5,7 @@ import lib.transmission_queue as tq
 from lib.message import Message
 from lib.naive import NaiveMessage
 from lib.pycubed import cubesat, HardwareInitException
+from state_machine import state_machine
 import struct
 
 msg = """"Did you ever hear the tragedy of Darth Plagueis the Wise?"
@@ -55,14 +56,17 @@ class task(Task):
         gyro = cubesat.gyro
         acc = cubesat.acceleration
         mag = cubesat.magnetic
+        state_byte = state_machine.states.index(state_machine.state)
+        state_byte = bytes([state_byte])
         print(f'CPU temp: {cpu_temp}')
         print(f'IMU temp: {imu_temp}')
         print(f'Gyro: {gyro}')
         print(f'Acceleration: {acc}')
         print(f'Magnetic: {mag}')
-        print(f'State: {cubesat.state_machine.state}')
-        return struct.pack("f" * 11,
-                           cpu_temp, imu_temp,
+        print(f'State: {state_machine.state} [{state_byte}]')
+        format = 'c' + 'f' * 11  # 1 char + 11 floats
+        return struct.pack(format,
+                           state_byte, cpu_temp, imu_temp,
                            gyro[0], gyro[1], gyro[2],
                            acc[0], acc[1], acc[2],
                            mag[0], mag[1], mag[2])

--- a/state_machine/applications/flight/Tasks/beacon_task.py
+++ b/state_machine/applications/flight/Tasks/beacon_task.py
@@ -57,14 +57,13 @@ class task(Task):
         acc = cubesat.acceleration
         mag = cubesat.magnetic
         state_byte = state_machine.states.index(state_machine.state)
-        state_byte = bytes([state_byte])
         print(f'CPU temp: {cpu_temp}')
         print(f'IMU temp: {imu_temp}')
         print(f'Gyro: {gyro}')
         print(f'Acceleration: {acc}')
         print(f'Magnetic: {mag}')
         print(f'State: {state_machine.state} [{state_byte}]')
-        format = 'c' + 'f' * 11  # 1 char + 11 floats
+        format = 'b' + 'f' * 11  # 1 char + 11 floats
         return struct.pack(format,
                            state_byte, cpu_temp, imu_temp,
                            gyro[0], gyro[1], gyro[2],

--- a/state_machine/applications/flight/Tasks/beacon_task.py
+++ b/state_machine/applications/flight/Tasks/beacon_task.py
@@ -4,6 +4,8 @@ from lib.template_task import Task
 import lib.transmission_queue as tq
 from lib.message import Message
 from lib.naive import NaiveMessage
+from lib.pycubed import cubesat, HardwareInitException
+import struct
 
 msg = """"Did you ever hear the tragedy of Darth Plagueis the Wise?"
 "No."
@@ -32,9 +34,31 @@ class task(Task):
         set the above ANTENNA_ATTACHED variable to True
         to actually send the beacon packet
         """
-        tq.push(Message(10, "Hello World!"))
+
+        beacon_packet = self.beacon_packet()
+        tq.push(Message(10, beacon_packet))
         if self.first_time:
             self.first_time = False
             self.debug("Pushing the large msg to tq")
             tq.push(NaiveMessage(1, msg))
         self.debug("Beacon task pushing to tq")
+
+    def beacon_packet(self):
+        try:
+            _ = cubesat.imu
+        except HardwareInitException as e:
+            print(f'IMU not initialized: {e}')
+            return bytes([0, 0, 0, 0, 0])
+
+        cpu_temp = cubesat.temperature_cpu
+        imu_temp = cubesat.temperature_imu
+        gyro = cubesat.gyro
+        acc = cubesat.acceleration
+        mag = cubesat.magnetic
+        print(f'CPU temp: {cpu_temp}')
+        print(f'IMU temp: {imu_temp}')
+        print(f'Gyro: {gyro}')
+        print(f'Acceleration: {acc}')
+        print(f'Magnetic: {mag}')
+        print(f'State: {cubesat.state_machine.state}')
+        return struct.pack("f" * 11, cpu_temp, imu_temp, gyro[0], gyro[1], gyro[2], acc[0], acc[1], acc[2], mag[0], mag[1], mag[2])

--- a/state_machine/applications/flight/Tasks/radio.py
+++ b/state_machine/applications/flight/Tasks/radio.py
@@ -30,11 +30,8 @@ class task(Task):
         'exec_cmd':     cdh.exec_cmd,
     }
 
-    def __init__(self, satellite):
-        # Copy pasted from beacon_task.py, not sure about the purpose
-        # Or if we need it for our protocol.
-        super().__init__(satellite)
-        # set our radiohead node ID so we can get ACKs
+    def __init__(self):
+        super().__init__()
         self.msg = ''
 
     async def main_task(self):
@@ -52,7 +49,7 @@ class task(Task):
                 header = response[0]
                 response = response[1:]  # remove the header byte
 
-                self.debug(f'Recieved msg "{response}", RSSI: {self.cubesat.radio.last_rssi - 137}')
+                self.debug(f'Recieved msg "{response}", RSSI: {cubesat.radio.last_rssi - 137}')
 
                 if header == headers.NAIVE_START or header == headers.NAIVE_MID or header == headers.NAIVE_END:
                     self.handle_naive(header, response)
@@ -107,7 +104,7 @@ class task(Task):
 
             if tq.peek().done():
                 tq.pop()
-        self.cubesat.radio.sleep()
+        cubesat.radio.sleep()
 
     def handle_naive(self, header, response):
         if header == headers.NAIVE_START:

--- a/state_machine/applications/flight/Tasks/safety.py
+++ b/state_machine/applications/flight/Tasks/safety.py
@@ -1,5 +1,6 @@
 from lib.template_task import Task
 from lib.pycubed import cubesat
+from state_machine import state_machine
 
 
 class task(Task):
@@ -20,15 +21,15 @@ class task(Task):
         else:
             self.debug_status(vbatt, temp)
             self.debug('Safe operating conditions reached, switching to normal mode')
-            cubesat.state_machine.switch_to('Normal')
+            state_machine.switch_to('Normal')
 
     def other_modes(self, vbatt, temp):
         if vbatt < cubesat.LOW_VOLTAGE:
             self.debug(f'Voltage too low ({vbatt:.1f}V < {cubesat.LOW_VOLTAGE:.1f}V) switch to safe mode')
-            cubesat.state_machine.switch_to('Safe')
+            state_machine.switch_to('Safe')
         elif temp > cubesat.HIGH_TEMP:
             self.debug(f'Temp too high ({temp:.1f}°C > {cubesat.HIGH_TEMP:.1f}°C) switching to safe mode')
-            cubesat.state_machine.switch_to('Safe')
+            state_machine.switch_to('Safe')
         else:
             self.debug_status(vbatt, temp)
 
@@ -39,7 +40,7 @@ class task(Task):
         """
         vbatt = cubesat.battery_voltage
         temp = cubesat.temperature_cpu
-        if cubesat.state_machine.state == 'Safe':
+        if state_machine.state == 'Safe':
             self.safe_mode(vbatt, temp)
         else:
             self.other_modes(vbatt, temp)

--- a/state_machine/applications/flight/lib/message.py
+++ b/state_machine/applications/flight/lib/message.py
@@ -5,12 +5,14 @@ class Message:
     :param priority: The priority of the message (higher is better)
     :type priority: int
     :param str: The message to send
-    :type str: str
+    :type str: str | bytes | bytearray
     """
 
     def __init__(self, priority, str):
         self.priority = priority
         self.header = 0x00
+        if isinstance(str, bytes) or isinstance(str, bytearray):
+            self.str = str
         self.str = bytes(str, 'ascii')
 
     def packet(self):

--- a/state_machine/applications/flight/lib/message.py
+++ b/state_machine/applications/flight/lib/message.py
@@ -13,7 +13,8 @@ class Message:
         self.header = 0x00
         if isinstance(str, bytes) or isinstance(str, bytearray):
             self.str = str
-        self.str = bytes(str, 'ascii')
+        else:
+            self.str = bytes(str, 'ascii')
 
     def packet(self):
         """Returns the byte representation of the message, and if it should be sent with or without ack."""

--- a/state_machine/applications/flight/lib/naive.py
+++ b/state_machine/applications/flight/lib/naive.py
@@ -8,7 +8,7 @@ class NaiveMessage(Message):
     :param priority: The priority of the message (higher is better)
     :type priority: int
     :param str: The message to send
-    :type str: str
+    :type str: str | bytes | bytearray
     """
 
     packet_len = 249  # not 251 because for some reason packet loss is extremely high at this threshold

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -125,9 +125,13 @@ class Satellite:
         print(f'log not implemented, tried to log: {str}')
 
     @property
-    def sun_vector():
+    def sun_vector(self):
         """Returns the sun pointing vector in the body frame"""
         return array([0, 0, 0])
+
+    @property
+    def imu(self):
+        return None
 
 
 cubesat = Satellite()

--- a/state_machine/drivers/example/lib/pycubed.py
+++ b/state_machine/drivers/example/lib/pycubed.py
@@ -1,20 +1,15 @@
 import time
 
-def acceleration():
-    return (0.0, 0.0, 0.0)
+class Satellite:
 
-def magnetic():
-    return (0.0, 0.0, 0.0)
-
-def gyro():
-    return (0.0, 0.0, 0.0)
-
-def temperature_imu():
-    return 20
-
-def battery_voltage():
-    return 6.4
+    def __init__(self):
+        self.acceleration = (0.0, 0.0, 0.0)
+        self.magnetic = (0.0, 0.0, 0.0)
+        self.gyro = (0.0, 0.0, 0.0)
+        self.temperature_imu = 20.0
+        self.battery_voltage = 6.4
+        self.vlowbatt = 4.0
+        self.BOOTTIME = time.monotonic()
 
 
-BOOTTIME = time.monotonic()
-vlowbatt = 4.0
+cubesat = Satellite()

--- a/state_machine/frame/lib/template_task.py
+++ b/state_machine/frame/lib/template_task.py
@@ -1,5 +1,5 @@
 from lib.debugcolor import co
-from lib.pycubed import cubesat
+from state_machine import state_machine
 
 
 class Task:
@@ -12,14 +12,11 @@ class Task:
     name = 'temp'
     color = 'gray'
 
-    def __init__(self, satellite):
+    def __init__(self):
         """
-        Initialize the Task using the PyCubed cubesat object.
-
-        :param satellite: The cubesat to be registered
-        :type satellite: Satellite
+        Initialize the Task
         """
-        self.cubesat = satellite
+        pass
 
     def debug(self, msg, level=1):
         """
@@ -31,7 +28,7 @@ class Task:
         :type level: int
         """
         if level == 1:
-            header = f"[{co(msg=self.name,color=self.color)}/{cubesat.state_machine.state}]"
+            header = f"[{co(msg=self.name,color=self.color)}/{state_machine.state}]"
             print(f"{header:>35} {msg}")
         else:
             print("\t" + f"{'   └── '}{msg}")

--- a/state_machine/frame/main.py
+++ b/state_machine/frame/main.py
@@ -1,12 +1,12 @@
 import traceback
 from lib.pycubed import cubesat
-import state_machine
+from state_machine import state_machine
 
 
 print('Running...')
 try:
     # should run forever
-    _ = state_machine.StateMachine(cubesat, 'Normal')
+    state_machine.start('Normal')
 except Exception as e:
     formated_exception = traceback.format_exception(e, e, e.__traceback__)
     for line in formated_exception:

--- a/state_machine/frame/state_machine.py
+++ b/state_machine/frame/state_machine.py
@@ -20,6 +20,7 @@ class StateMachine:
         from StateMachineConfig import config, TaskMap, TransitionFunctionMap
 
         self.config = config
+        self.transition_function_map = TransitionFunctionMap
         validate_config(config, TaskMap, TransitionFunctionMap)
 
         self.states = list(config.keys())
@@ -50,11 +51,11 @@ class StateMachine:
 
         # execute transition functions
         if self.state != state_name:
-            for fn in config[self.state]['ExitFunctions']:
-                fn = TransitionFunctionMap[fn]
+            for fn in self.config[self.state]['ExitFunctions']:
+                fn = self.transition_function_map[fn]
                 fn(self.state, state_name, cubesat)
-            for fn in config[state_name]['EnterFunctions']:
-                fn = TransitionFunctionMap[fn]
+            for fn in self.config[state_name]['EnterFunctions']:
+                fn = self.transition_function_map[fn]
                 fn(self.state, state_name, cubesat)
 
         # reschedule tasks

--- a/state_machine/frame/state_machine.py
+++ b/state_machine/frame/state_machine.py
@@ -41,8 +41,13 @@ class StateMachine:
         for _, task in self.scheduled_tasks.items():
             task.stop()
 
-    def switch_to(self, state_name, force=False):
-        """Switches the state of the cubesat to the new state"""
+    def switch_to(self, state_name: str, force=False):
+        """Switches the state of the cubesat to the new state
+
+        Args:
+        :param state_name: The name of the state to switch to
+        :type state_name: str
+        """
 
         # prevent (or allow forced) illegal transitions
         if not (state_name in self.config[self.state]['StepsTo'] or force):

--- a/state_machine/frame/state_machine.py
+++ b/state_machine/frame/state_machine.py
@@ -45,7 +45,7 @@ class StateMachine:
         """Switches the state of the cubesat to the new state"""
 
         # prevent (or allow forced) illegal transitions
-        if not(state_name in self.config[self.state]['StepsTo'] or force):
+        if not (state_name in self.config[self.state]['StepsTo'] or force):
             raise ValueError(
                 f'You cannot transition from {self.state} to {state_name}')
 

--- a/state_machine/frame/state_machine.py
+++ b/state_machine/frame/state_machine.py
@@ -1,39 +1,39 @@
 import tasko
+from lib.pycubed import cubesat
 
-from StateMachineConfig import config, TaskMap, TransitionFunctionMap
 from lib.state_machine_utils import validate_config
 
 
 class StateMachine:
     """Singleton State Machine Class"""
 
-    def __init__(self, cubesat, start_state):
+    def __init__(self):
+        pass
+
+    def start(self, start_state: str):
+        """Starts the state machine
+
+        Args:
+        :param start_state: The state to start the state machine in
+        :type start_state: str
+        """
+        from StateMachineConfig import config, TaskMap, TransitionFunctionMap
+
         self.config = config
         validate_config(config, TaskMap, TransitionFunctionMap)
 
-        self.state = start_state
-
-        # allow access to cubesat object
-        self.cubesat = cubesat
-
-        # create shared asyncio object
-        self.tasko = tasko
-
-        # supports legacy code, only the state machine should use tasko
-        cubesat.tasko = tasko
+        self.states = list(config.keys())
+        self.states.sort()
 
         # init task objects
-        self.tasks = {key: task(cubesat) for key, task in TaskMap.items()}
+        self.tasks = {key: task() for key, task in TaskMap.items()}
 
         # set scheduled tasks to none
         self.scheduled_tasks = {}
 
-        # Make state machine accesible to cubesat
-        cubesat.state_machine = self
-
-        # switch to start state, and start event loop
+        self.state = start_state
         self.switch_to(start_state, force=True)
-        self.tasko.run()
+        tasko.run()
 
     def stop_all(self):
         """Stops all running tasko processes"""
@@ -43,7 +43,7 @@ class StateMachine:
     def switch_to(self, state_name, force=False):
         """Switches the state of the cubesat to the new state"""
 
-        # prevent (or force) illegal transitions
+        # prevent (or allow forced) illegal transitions
         if not(state_name in self.config[self.state]['StepsTo'] or force):
             raise ValueError(
                 f'You cannot transition from {self.state} to {state_name}')
@@ -52,10 +52,10 @@ class StateMachine:
         if self.state != state_name:
             for fn in config[self.state]['ExitFunctions']:
                 fn = TransitionFunctionMap[fn]
-                fn(self.state, state_name, self.cubesat)
+                fn(self.state, state_name, cubesat)
             for fn in config[state_name]['EnterFunctions']:
                 fn = TransitionFunctionMap[fn]
-                fn(self.state, state_name, self.cubesat)
+                fn(self.state, state_name, cubesat)
 
         # reschedule tasks
         self.stop_all()
@@ -65,9 +65,9 @@ class StateMachine:
 
         for task_name, props in state_config['Tasks'].items():
             if props['ScheduleLater']:
-                schedule = self.tasko.schedule_later
+                schedule = tasko.schedule_later
             else:
-                schedule = self.tasko.schedule
+                schedule = tasko.schedule
 
             frequency = 1 / props['Interval']
             priority = props['Priority']
@@ -75,3 +75,6 @@ class StateMachine:
 
             self.scheduled_tasks[task_name] = schedule(
                 frequency, task_fn, priority)
+
+
+state_machine = StateMachine()


### PR DESCRIPTION
Needed to rewrite the state machine a tinny bit, so I figured I might as well finally get to the refactor I've been meaning to do.
Finally removes the ability to do this style of coding in tasks:
```python
self.cubesat
self.cubesat.state_machine
sef.cubesat.state_machine.tasko
```
And instead we just use imports

Also fixed the broken `example` app/driver
