### PR TITLE
Cleanup driver

### DIFF
--- a/state_machine/applications/flight/Tasks/blink_task.py
+++ b/state_machine/applications/flight/Tasks/blink_task.py
@@ -11,9 +11,10 @@ class task(Task):
     rgb_on = False
 
     async def main_task(self):
-        if self.rgb_on:
-            cubesat.RGB = (0, 0, 0)
-            self.rgb_on = False
-        else:
-            cubesat.RGB = (50, 0, 50)
-            self.rgb_on = True
+        if cubesat.neopixel:
+            if self.rgb_on:
+                cubesat.RGB = (0, 0, 0)
+                self.rgb_on = False
+            else:
+                cubesat.RGB = (50, 0, 50)
+                self.rgb_on = True

--- a/state_machine/applications/flight/Tasks/blink_task.py
+++ b/state_machine/applications/flight/Tasks/blink_task.py
@@ -11,10 +11,12 @@ class task(Task):
     rgb_on = False
 
     async def main_task(self):
-        if cubesat.neopixel:
-            if self.rgb_on:
-                cubesat.RGB = (0, 0, 0)
-                self.rgb_on = False
-            else:
-                cubesat.RGB = (50, 0, 50)
-                self.rgb_on = True
+        if not cubesat.neopixel:
+            self.debug('No neopixel attached, skipping blink task')
+            return
+        if self.rgb_on:
+            cubesat.RGB = (0, 0, 0)
+            self.rgb_on = False
+        else:
+            cubesat.RGB = (50, 0, 50)
+            self.rgb_on = True

--- a/state_machine/applications/flight/Tasks/imu_task.py
+++ b/state_machine/applications/flight/Tasks/imu_task.py
@@ -8,6 +8,8 @@ class task(Task):
     data_file = None
 
     async def main_task(self):
+        if not cubesat.imu:
+            return
         # take IMU readings
         readings = {
             'accel': cubesat.acceleration,

--- a/state_machine/applications/flight/Tasks/radio.py
+++ b/state_machine/applications/flight/Tasks/radio.py
@@ -38,8 +38,11 @@ class task(Task):
         self.msg = ''
 
     async def main_task(self):
-        if not cubesat.radio or not ANTENNA_ATTACHED:
+        if not cubesat.radio:
             self.debug('No radio attached, skipping radio task')
+            return
+        elif not ANTENNA_ATTACHED:
+            self.debug('No antenna attached, skipping radio task')
             return
 
         if tq.empty():

--- a/state_machine/applications/flight/Tasks/radio.py
+++ b/state_machine/applications/flight/Tasks/radio.py
@@ -7,7 +7,7 @@ from lib.template_task import Task
 import lib.transmission_queue as tq
 import cdh
 import lib.radio_headers as headers
-from lib.pycubed import cubesat, HardwareInitException
+from lib.pycubed import cubesat
 
 ANTENNA_ATTACHED = False
 
@@ -38,9 +38,7 @@ class task(Task):
         self.msg = ''
 
     async def main_task(self):
-        try:
-            _ = cubesat.radio
-        except HardwareInitException:
+        if not cubesat.radio or not ANTENNA_ATTACHED:
             self.debug('No radio attached, skipping radio task')
             return
 

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -49,13 +49,6 @@ class device:
 
 
 """
-Define HardwareInitException
-"""
-class HardwareInitException(Exception):
-    pass
-
-
-"""
 Define constants, Satellite attributes and Satellite Class
 """
 # NVM register numbers
@@ -118,15 +111,15 @@ class _Satellite:
         self.neopixel
         self.imu
         self.radio
-        self.sun_minusy
-        self.sun_minusz
-        self.sun_minusx
-        self.sun_plusy
-        self.sun_plusz
-        self.sun_plusx
-        self.coildriverx
-        self.coildrivery
-        self.coildriverz
+        self.sun_xn
+        self.sun_yn
+        self.sun_zn
+        self.sun_xp
+        self.sun_yp
+        self.sun_zp
+        self.drv_x
+        self.drv_y
+        self.drv_z
         self.burnwire1
         self.burnwire2
 

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -223,9 +223,7 @@ class _Satellite:
     def sun_yn(self):
         """ Initialize the -Y sun sensor on I2C2 """
         try:
-            sun_yn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x29)
-            sun_yn.enabled = False
-            return sun_yn
+            return adafruit_tsl2561.TSL2561(self.i2c3, address=0x29)
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor -Y]', e)
 
@@ -233,9 +231,7 @@ class _Satellite:
     def sun_zn(self):
         """ Initialize the -Z sun sensor on I2C2 """
         try:
-            sun_zn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x39)
-            sun_zn.enabled = False
-            return sun_zn
+            return adafruit_tsl2561.TSL2561(self.i2c3, address=0x39)
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor -Z]', e)
 
@@ -243,9 +239,7 @@ class _Satellite:
     def sun_xn(self):
         """ Initialize the -X sun sensor on I2C1 """
         try:
-            sun_xn = adafruit_tsl2561.TSL2561(self.i2c2, address=0x29)
-            sun_xn.enabled = False
-            return sun_xn
+            return adafruit_tsl2561.TSL2561(self.i2c2, address=0x49)
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor -X]', e)
 
@@ -253,9 +247,7 @@ class _Satellite:
     def sun_yp(self):
         """ Initialize the +Y sun sensor on I2C1 """
         try:
-            sun_yp = adafruit_tsl2561.TSL2561(self.i2c3, address=0x49)
-            sun_yp.enabled = False
-            return sun_yp
+            return adafruit_tsl2561.TSL2561(self.i2c3, address=0x49)
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor +Y]', e)
 
@@ -263,9 +255,7 @@ class _Satellite:
     def sun_zp(self):
         """ Initialize the +Z sun sensor on I2C1 """
         try:
-            sun_zp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x39)
-            sun_zp.enabled = False
-            return sun_zp
+            return adafruit_tsl2561.TSL2561(self.i2c2, address=0x39)
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor +Z]', e)
 
@@ -273,9 +263,7 @@ class _Satellite:
     def sun_xp(self):
         """ Initialize the +X sun sensor on I2C2 """
         try:
-            sun_xp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x49)
-            sun_xp.enabled = False
-            return sun_xp
+            return adafruit_tsl2561.TSL2561(self.i2c2, address=0x29)
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor +X]', e)
 

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -23,8 +23,8 @@ import adafruit_tsl2561
 import time
 from ulab.numpy import array
 
-class hardware:
-    """Modified @hardware decorator.
+class device:
+    """
     Based on the code from: https://docs.python.org/3/howto/descriptor.html#properties
     Attempts to return the appropriate hardware device.
     If this fails, it will attempt to reinitialize the hardware.
@@ -33,24 +33,19 @@ class hardware:
 
     def __init__(self, fget=None):
         self.fget = fget
+        self._device = None
 
-    def __get__(self, obj, objtype=None):
-        if obj is None:
+    def __get__(self, instance, owner=None):
+        if instance is None:
             return self
         if self.fget is None:
             raise AttributeError(f'unreadable attribute {self._name}')
 
-        device, reinit = self.fget(obj)
-
-        if device is not None:
-            return device
+        if self._device is not None:
+            return self._device
         else:
-            reinit()
-            device, _ = self.fget(obj)
-            if device is None:
-                raise HardwareInitException
-            else:
-                return device
+            self._device = self.fget(instance)
+            return self._device
 
 
 """
@@ -86,13 +81,6 @@ class _Satellite:
     c_downlink = multiBitFlag(register=_DWNLINK, lowest_bit=0, num_bits=8)
     c_logfail = multiBitFlag(register=_LOGFAIL, lowest_bit=0, num_bits=8)
 
-    # Set hardware attributes to None
-    # Needed for things not to crash
-    _i2c1, _i2c2, _i2c3, _spi, _sd, _neopixel = None, None, None, None, None, None
-    _imu, _radio, _sun_yn, _sun_zn, _sun_xn = None, None, None, None, None
-    _sun_yp, _sun_zp, _sun_xp, _drv_x, _drv_y = None, None, None, None, None
-    _drv_z, _burnwire1, _burnwire2 = None, None, None
-
     UHF_FREQ = 433.0
 
     instance = None
@@ -117,115 +105,102 @@ class _Satellite:
 
     def __init__(self):
         """ Big init routine as the whole board is brought up. """
-        self.hardware = {
-            'I2C1': False,
-            'I2C2': False,
-            'I2C3': False,
-            'SPI': False,
-            'SDcard': False,
-            'Neopixel': False,
-            'IMU': False,
-            'Radio': False,
-            'Sun-Y': False,
-            'Sun-Z': False,
-            'Sun-X': False,
-            'Sun+Y': False,
-            'Sun+Z': False,
-            'Sun+X': False,
-            'CoilDriverX': False,
-            'CoilDriverY': False,
-            'CoilDriverZ': False,
-            'Burnwire1': False,
-            'Burnwire2': False,
-            'WDT': False  # Watch Dog Timer pending
-        }
         self.BOOTTIME = int(time.monotonic())  # get monotonic time at initialization
         self.micro = microcontroller
         self._vbatt = analogio.AnalogIn(board.BATTERY)  # Battery voltage
 
-        # Define and initialize hardware
-        self._init_i2c1()
-        self._init_i2c2()
-        self._init_i2c3()
-        self._init_spi()
-        self._init_sdcard()
-        self._init_neopixel()
-        self._init_imu()
-        self._init_radio()
-        self._init_sun_minusy()
-        self._init_sun_minusz()
-        self._init_sun_minusx()
-        self._init_sun_plusy()
-        self._init_sun_plusz()
-        self._init_sun_plusx()
-        self._init_coildriverx()
-        self._init_coildrivery()
-        self._init_coildriverz()
-        self._init_burnwire1()
-        self._init_burnwire2()
+        # To force initialization of hardware
+        self.i2c1
+        self.i2c2
+        self.i2c3
+        self.spi
+        self.sdcard
+        self.neopixel
+        self.imu
+        self.radio
+        self.sun_minusy
+        self.sun_minusz
+        self.sun_minusx
+        self.sun_plusy
+        self.sun_plusz
+        self.sun_plusx
+        self.coildriverx
+        self.coildrivery
+        self.coildriverz
+        self.burnwire1
+        self.burnwire2
 
-    def _init_i2c1(self):
+    @device
+    def i2c1(self):
         """ Initialize I2C1 bus """
         try:
-            self._i2c1 = busio.I2C(board.SCL1, board.SDA1)
-            self.hardware['I2C1'] = True
+            return busio.I2C(board.SCL1, board.SDA1)
         except Exception as e:
             print("[ERROR][Initializing I2C1]", e)
 
-    def _init_i2c2(self):
+    @device
+    def i2c2(self):
         """ Initialize I2C2 bus """
         try:
-            self._i2c2 = busio.I2C(board.SCL2, board.SDA2)
-            self.hardware['I2C2'] = True
+            return busio.I2C(board.SCL2, board.SDA2)
         except Exception as e:
             print("[ERROR][Initializing I2C2]", e)
 
-    def _init_i2c3(self):
+    @device
+    def i2c3(self):
         """ Initialize I2C3 bus """
         try:
-            self._i2c3 = busio.I2C(board.SCL3, board.SDA3)
-            self.hardware['I2C3'] = True
+            return busio.I2C(board.SCL3, board.SDA3)
         except Exception as e:
             print("[ERROR][Initializing I2C3]", e)
 
-    def _init_spi(self):
+    @device
+    def spi(self):
         """ Initialize SPI bus """
         try:
-            self._spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
-            self.hardware['SPI'] = True
+            return busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
         except Exception as e:
             print("[ERROR][Initializing SPI]", e)
 
-    def _init_sdcard(self):
+    @device
+    def sdcard(self):
         """ Define SD Parameters and initialize SD Card """
         try:
-            self._sd = sdcardio.SDCard(self.spi, board.CS_SD, baudrate=4000000)
-            self._vfs = storage.VfsFat(self.sd)
-            storage.mount(self._vfs, "/sd")
-            sys.path.append("/sd")
-            self.hardware['SDcard'] = True
+            return sdcardio.SDCard(self.spi, board.CS_SD, baudrate=4000000)
         except Exception as e:
             print('[ERROR][Initializing SD Card]', e)
 
-    def _init_neopixel(self):
+    @device
+    def vfs(self):
+        try:
+            vfs = storage.VfsFat(self.sd)
+            storage.mount(vfs, "/sd")
+            sys.path.append("/sd")
+            return vfs
+        except Exception as e:
+            print('[ERROR][Initializing VFS]', e)
+
+    @device
+    def neopixel(self):
         """ Define neopixel parameters and initialize """
         try:
-            self._neopixel = neopixel.NeoPixel(
+            led = neopixel.NeoPixel(
                 board.NEOPIXEL, 1, brightness=0.2, pixel_order=neopixel.GRB)
-            self.neopixel[0] = (0, 0, 0)
-            self.hardware['Neopixel'] = True
+            led[0] = (0, 0, 0)
+            return led
         except Exception as e:
             print('[ERROR][Initializing Neopixel]', e)
 
-    def _init_imu(self):
+    @device
+    def imu(self):
         """ Define IMU parameters and initialize """
         try:
-            self._imu = bmx160.BMX160_I2C(self.i2c1, address=0x68)
-            self.hardware['IMU'] = True
+            return bmx160.BMX160_I2C(self.i2c1, address=0x68)
         except Exception as e:
             print(f'[ERROR][Initializing IMU] {e}\n\tMaybe try address=0x68?')
 
-    def _init_radio(self):
+    @device
+    def radio(self):
         """ Define radio parameters and initialize UHF radio """
         try:
             self._rf_cs = digitalio.DigitalInOut(board.RF_CS)
@@ -240,88 +215,97 @@ class _Satellite:
             print('[ERROR][Initializing Radio]', e)
 
         try:
-            self._radio = pycubed_rfm9x.RFM9x(
+            radio = pycubed_rfm9x.RFM9x(
                 self.spi, self._rf_cs, self._rf_rst,
                 self.UHF_FREQ)
-            self.radio.dio0 = self.radio_DIO0
-            self._radio.node = 0xAB  # our ID
-            self._radio.destination = 0xBA  # target's ID
-            self.radio.sleep()
-            self.hardware['Radio'] = True
+            radio.dio0 = self.radio_DIO0
+            radio.node = 0xAB  # our ID
+            radio.destination = 0xBA  # target's ID
+            radio.sleep()
+            return radio
         except Exception as e:
             print('[ERROR][Initializing RADIO]', e)
 
-    def _init_sun_minusy(self):
+    @device
+    def sun_minusy(self):
         """ Initialize the -Y sun sensor on I2C2 """
         try:
-            self._sun_yn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x29)
-            self.sun_yn.enabled = False
-            self.hardware['Sun-Y'] = True
+            sun_yn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x29)
+            sun_yn.enabled = False
+            return sun_yn
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor -Y]', e)
 
-    def _init_sun_minusz(self):
+    @device
+    def sun_minusz(self):
         """ Initialize the -Z sun sensor on I2C2 """
         try:
-            self._sun_zn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x39)
-            self.sun_zn.enabled = False
-            self.hardware['Sun-Z'] = True
+            sun_zn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x39)
+            sun_zn.enabled = False
+            return sun_zn
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor -Z]', e)
 
-    def _init_sun_minusx(self):
+    @device
+    def sun_minusx(self):
         """ Initialize the -X sun sensor on I2C1 """
         try:
-            self._sun_xn = adafruit_tsl2561.TSL2561(self.i2c2, address=0x29)
-            self.sun_xn.enabled = False
-            self.hardware['Sun-X'] = True
+            sun_xn = adafruit_tsl2561.TSL2561(self.i2c2, address=0x29)
+            sun_xn.enabled = False
+            return sun_xn
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor -X]', e)
 
-    def _init_sun_plusy(self):
+    @device
+    def sun_plusy(self):
         """ Initialize the +Y sun sensor on I2C1 """
         try:
-            self._sun_yp = adafruit_tsl2561.TSL2561(self.i2c3, address=0x49)
-            self.sun_yp.enabled = False
-            self.hardware['Sun+Y'] = True
+            sun_yp = adafruit_tsl2561.TSL2561(self.i2c3, address=0x49)
+            sun_yp.enabled = False
+            return sun_yp
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor +Y]', e)
 
-    def _init_sun_plusz(self):
+    @device
+    def sun_plusz(self):
         """ Initialize the +Z sun sensor on I2C1 """
         try:
-            self._sun_zp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x39)
-            self.sun_zp.enabled = False
-            self.hardware['Sun+Z'] = True
+            sun_zp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x39)
+            sun_zp.enabled = False
+            return sun_zp
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor +Z]', e)
 
-    def _init_sun_plusx(self):
+    @device
+    def sun_plusx(self):
         """ Initialize the +X sun sensor on I2C2 """
         try:
-            self._sun_xp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x49)
-            self.sun_xp.enabled = False
-            self.hardware['Sun+X'] = True
+            sun_xp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x49)
+            sun_xp.enabled = False
+            return sun_xp
         except Exception as e:
             print('[ERROR][Initializing Sun Sensor +X]', e)
 
-    def _init_coildriverx(self):
+    @device
+    def coildriverx(self):
         """ Initialize Coil Driver X on I2C3, set mode and voltage """
         try:
-            self._drv_x = drv8830.DRV8830(self.i2c1, 0xC4 >> 1)  # U7
-            self.hardware['CoilDriverX'] = True
+            drv_x = drv8830.DRV8830(self.i2c1, 0xC4 >> 1)  # U7
+            return drv_x
         except Exception as e:
             print('[ERROR][Initializing H-Bridge U7]', e)
 
-    def _init_coildrivery(self):
+    @device
+    def coildrivery(self):
         """ Initialize Coil Driver Y on I2C3, set mode and voltage """
         try:
-            self._drv_y = drv8830.DRV8830(self.i2c1, 0xC0 >> 1)  # U8
-            self.hardware['CoilDriverY'] = True
+            drv_y = drv8830.DRV8830(self.i2c1, 0xC0 >> 1)  # U8
+            return drv_y
         except Exception as e:
             print('[ERROR][Initializing H-Bridge U8]', e)
 
-    def _init_coildriverz(self):
+    @device
+    def coildriverz(self):
         """ Initialize Coil Driver Z on I2C3, set mode and voltage """
         try:
             self._drv_z = drv8830.DRV8830(self.i2c1, 0xD0 >> 1)  # U9
@@ -329,148 +313,53 @@ class _Satellite:
         except Exception as e:
             print('[ERROR][Initializing H-Bridge U9]', e)
 
-    def _init_burnwire1(self):
+    @device
+    def burnwire1(self):
         """ Initialize Burnwire1 on PA19 """
         # TODO: update firmware so we can use board.BURN1
         try:
             # changed pinout from BURN1 to PA19 (BURN1 did not support PWMOut)
-            self._burnwire1 = pwmio.PWMOut(
+            return pwmio.PWMOut(
                 microcontroller.pin.PA19, frequency=1000, duty_cycle=0)
-            self.hardware['Burnwire1'] = True
         except Exception as e:
             print('[ERROR][Initializing Burn Wire IC1]', e)
 
-    def _init_burnwire2(self):
+    @device
+    def burnwire2(self):
         """ Initialize Burnwire2 on PA18 """
         # TODO: update firmware so we can use board.BURN2
         try:
             # changed pinout from BURN2 to PA18 (BURN2 did not support PWMOut)
-            self._burnwire2 = pwmio.PWMOut(
-                microcontroller.pin.PA18, frequency=1000, duty_cycle=0)
             # Initializing Burn Wire 2 hardware as false; no corresponding IC
-            self.hardware['Burnwire2'] = False
+            return pwmio.PWMOut(
+                microcontroller.pin.PA18, frequency=1000, duty_cycle=0)
         except Exception as e:
             print('[ERROR][Initializing Burn Wire IC2]', e)
 
-    @hardware
-    def i2c1(self):
-        """ Return I2C1 bus and init function"""
-        return self._i2c1, self._init_i2c1
-
-    @hardware
-    def i2c2(self):
-        """ Return I2C2 bus object and init function"""
-        return self._i2c2, self._init_i2c2
-
-    @hardware
-    def i2c3(self):
-        """ Return I2C3 bus object and init function"""
-        return self._i2c3, self._init_i2c3
-
-    @hardware
-    def spi(self):
-        """ Return SPI bus object and init function"""
-        return self._spi, self._init_i2c3
-
-    @hardware
-    def sd(self):
-        """ Return SD Card object and init function"""
-        return self._sd, self._init_i2c3
-
-    @hardware
-    def neopixel(self):
-        """Return neopixel and its init function"""
-        return self._neopixel, self._init_neopixel
-
-    @hardware
-    def imu(self):
-        """ Return IMU object and init function"""
-        return self._imu, self._init_imu
-
-    @hardware
-    def radio(self):
-        """ Return Radio and init function"""
-        return self._radio, self._init_radio
-
-    @hardware
-    def sun_yn(self):
-        """ Return Sun Sensor -Y and init function"""
-        return self._sun_yn, self._init_sun_minusy
-
-    @hardware
-    def sun_zn(self):
-        """ Return Sun Sensor -Z and init function"""
-        return self._sun_zn, self._init_sun_minusz
-
-    @hardware
-    def sun_xn(self):
-        """ Return Sun Sensor -X and init function"""
-        return self._sun_xn, self._init_sun_minusx
-
-    @hardware
-    def sun_yp(self):
-        """ Return Sun Sensor +Y and init function"""
-        return self._sun_yp, self._init_sun_plusy
-
-    @hardware
-    def sun_zp(self):
-        """ Return Sun Sensor +Z and init function"""
-        return self._sun_zp, self._init_sun_plusz
-
-    @hardware
-    def sun_xp(self):
-        """ Return Sun Sensor +X and init function"""
-        return self._sun_xp, self._init_sun_plusx
-
-    @hardware
-    def drv_x(self):
-        """ Return Coil Driver X and init function"""
-        return self._drv_x, self._init_coildriverx
-
-    @hardware
-    def drv_y(self):
-        """ Return Coil Driver Y and init function"""
-        return self._drv_y, self._init_coildrivery
-
-    @hardware
-    def drv_z(self):
-        """ Return Coil Driver Z and init function"""
-        return self._drv_z, self._init_coildriverz
-
-    @hardware
-    def burnwire1(self):
-        """ Return Burnwire1 object and init function"""
-        return self._burnwire1, self._init_burnwire1
-
-    @hardware
-    def burnwire2(self):
-        """ Return Burnwire2 object and init function"""
-        return self._burnwire2, self._init_burnwire2
-
-    @hardware
+    @property
     def acceleration(self):
         """ return the accelerometer reading from the IMU in m/s^2 """
-        return self.imu.accel, self._init_imu
+        return self.imu.accel if self.imu else None
 
-    @hardware
+    @property
     def magnetic(self):
         """ return the magnetometer reading from the IMU in µT """
-        return self.imu.mag, self._init_imu
+        return self.imu.mag if self.imu else None
 
-    @hardware
+    @property
     def gyro(self):
         """ return the gyroscope reading from the IMU in deg/s """
-        return self.imu.gyro, self._init_imu
+        return self.imu.gyro if self.imu else None
 
-    @hardware
+    @property
     def temperature_imu(self):
         """ return the thermometer reading from the IMU in celsius """
-        return self.imu.temperature, self._init_imu
+        return self.imu.temperature if self.imu else None
 
     @property
     def temperature_cpu(self):
         """ return the temperature reading from the CPU in celsius """
-        return self.micro.cpu.temperature
+        return self.micro.cpu.temperature if self.micro else None
 
     def coildriver_vout(self, driver_index, projected_voltage):
         """ Set a given voltage for a given coil driver """

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -375,7 +375,6 @@ class _Satellite:
         the voltage of the corresponding burnwire IC
         "dutycycle" tells us the proportion of total voltage we will
         run the IC at (ex. if "dtycycl" = 0.5, we burn at 1.65 volts)
-        initialize with default burn_num = '1' ; burnwire 2 IC is not set up
         """
         burnwire = self.burnwire1
         self.RGB = (255, 0, 0)

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -227,7 +227,7 @@ class _Satellite:
             print('[ERROR][Initializing RADIO]', e)
 
     @device
-    def sun_minusy(self):
+    def sun_yn(self):
         """ Initialize the -Y sun sensor on I2C2 """
         try:
             sun_yn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x29)
@@ -237,7 +237,7 @@ class _Satellite:
             print('[ERROR][Initializing Sun Sensor -Y]', e)
 
     @device
-    def sun_minusz(self):
+    def sun_zn(self):
         """ Initialize the -Z sun sensor on I2C2 """
         try:
             sun_zn = adafruit_tsl2561.TSL2561(self.i2c3, address=0x39)
@@ -247,7 +247,7 @@ class _Satellite:
             print('[ERROR][Initializing Sun Sensor -Z]', e)
 
     @device
-    def sun_minusx(self):
+    def sun_xn(self):
         """ Initialize the -X sun sensor on I2C1 """
         try:
             sun_xn = adafruit_tsl2561.TSL2561(self.i2c2, address=0x29)
@@ -257,7 +257,7 @@ class _Satellite:
             print('[ERROR][Initializing Sun Sensor -X]', e)
 
     @device
-    def sun_plusy(self):
+    def sun_yp(self):
         """ Initialize the +Y sun sensor on I2C1 """
         try:
             sun_yp = adafruit_tsl2561.TSL2561(self.i2c3, address=0x49)
@@ -267,7 +267,7 @@ class _Satellite:
             print('[ERROR][Initializing Sun Sensor +Y]', e)
 
     @device
-    def sun_plusz(self):
+    def sun_zp(self):
         """ Initialize the +Z sun sensor on I2C1 """
         try:
             sun_zp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x39)
@@ -277,7 +277,7 @@ class _Satellite:
             print('[ERROR][Initializing Sun Sensor +Z]', e)
 
     @device
-    def sun_plusx(self):
+    def sun_xp(self):
         """ Initialize the +X sun sensor on I2C2 """
         try:
             sun_xp = adafruit_tsl2561.TSL2561(self.i2c2, address=0x49)
@@ -287,29 +287,26 @@ class _Satellite:
             print('[ERROR][Initializing Sun Sensor +X]', e)
 
     @device
-    def coildriverx(self):
+    def drv_x(self):
         """ Initialize Coil Driver X on I2C3, set mode and voltage """
         try:
-            drv_x = drv8830.DRV8830(self.i2c1, 0xC4 >> 1)  # U7
-            return drv_x
+            return drv8830.DRV8830(self.i2c1, 0xC4 >> 1)  # U7
         except Exception as e:
             print('[ERROR][Initializing H-Bridge U7]', e)
 
     @device
-    def coildrivery(self):
+    def drv_y(self):
         """ Initialize Coil Driver Y on I2C3, set mode and voltage """
         try:
-            drv_y = drv8830.DRV8830(self.i2c1, 0xC0 >> 1)  # U8
-            return drv_y
+            return drv8830.DRV8830(self.i2c1, 0xC0 >> 1)  # U8
         except Exception as e:
             print('[ERROR][Initializing H-Bridge U8]', e)
 
     @device
-    def coildriverz(self):
+    def drv_z(self):
         """ Initialize Coil Driver Z on I2C3, set mode and voltage """
         try:
-            self._drv_z = drv8830.DRV8830(self.i2c1, 0xD0 >> 1)  # U9
-            self.hardware['CoilDriverZ'] = True
+            return drv8830.DRV8830(self.i2c1, 0xD0 >> 1)  # U9
         except Exception as e:
             print('[ERROR][Initializing H-Bridge U9]', e)
 


### PR DESCRIPTION
- Reworked @hardware decorator to remove the need for things like `_radio`. 
- Removed all the cubesat.hardware['something'] calls
- No longer using the `HardwareInitException`, programming with it turned out to be a total pain
    - Can't figure out a better way to check of existence than `cubesat.imu is not None`
- Should not change the interface 
- Coil drivers x/y working, z not working