### PR TITLE
Deployment state

### DIFF
--- a/state_machine/applications/example/config.py
+++ b/state_machine/applications/example/config.py
@@ -50,3 +50,5 @@ config = {
         ]
     }
 }
+
+initial = "Normal"

--- a/state_machine/applications/flight/StateMachineConfig.py
+++ b/state_machine/applications/flight/StateMachineConfig.py
@@ -5,6 +5,7 @@ from Tasks.imu_task import task as imu
 from Tasks.time_task import task as time
 from Tasks.gnc import task as gnc
 from Tasks.radio import task as radio
+from Tasks.deployment_manager import deployment_manager
 from TransitionFunctions import announcer, low_power_on, low_power_off
 from config import config  # noqa: F401
 
@@ -16,6 +17,7 @@ TaskMap = {
     "Time": time,
     "GNC": gnc,
     "Radio": radio,
+    "DeploymentManager": deployment_manager,
 }
 
 TransitionFunctionMap = {

--- a/state_machine/applications/flight/Tasks/deployment_manager.py
+++ b/state_machine/applications/flight/Tasks/deployment_manager.py
@@ -10,8 +10,8 @@ class deployment_manager(Task):
     rgb_on = False
 
     async def main_task(self):
-        # nvm shit
         if (cubesat.f_contact):
+            self.debug('Contact with ground station has been already established, switching to Normal mode')
             state_machine.switch_to('Normal')
         else:
             if await cubesat.burn(duration=15):

--- a/state_machine/applications/flight/Tasks/deployment_manager.py
+++ b/state_machine/applications/flight/Tasks/deployment_manager.py
@@ -11,11 +11,11 @@ class deployment_manager(Task):
 
     async def main_task(self):
         # nvm shit
-        if (cubesat.f_deploy):
+        if (cubesat.f_contact):
             state_machine.switch_to('Normal')
         else:
             if await cubesat.burn(duration=15):
-                self.deubg('Successfully burned')
+                self.debug('Successfully burned')
             else:
                 # Consider panic mode
                 self.deubg('Uncuccessful burn')

--- a/state_machine/applications/flight/Tasks/deployment_manager.py
+++ b/state_machine/applications/flight/Tasks/deployment_manager.py
@@ -1,0 +1,21 @@
+from lib.template_task import Task
+from pycubed import cubesat
+from state_machine import state_machine
+
+
+class deployment_manager(Task):
+    name = 'depoloyment_manager'
+    color = 'blue'
+
+    rgb_on = False
+
+    async def main_task(self):
+        # nvm shit
+        if (cubesat.f_deploy):
+            state_machine.switch_to('Normal')
+        else:
+            if await cubesat.burn(duration=15):
+                self.deubg('Successfully burned')
+            else:
+                # Consider panic mode
+                self.deubg('Uncuccessful burn')

--- a/state_machine/applications/flight/Tasks/deployment_manager.py
+++ b/state_machine/applications/flight/Tasks/deployment_manager.py
@@ -18,4 +18,4 @@ class deployment_manager(Task):
                 self.debug('Successfully burned')
             else:
                 # Consider panic mode
-                self.deubg('Uncuccessful burn')
+                self.debug('Unsuccessful burn')

--- a/state_machine/applications/flight/Tasks/radio.py
+++ b/state_machine/applications/flight/Tasks/radio.py
@@ -57,6 +57,7 @@ class task(Task):
             cubesat.radio.listen()
             response = await cubesat.radio.receive(keep_listening=True, with_ack=ANTENNA_ATTACHED, timeout=10)
             if response is not None:
+                cubesat.f_deploy = True
                 header = response[0]
                 response = response[1:]  # remove the header byte
 

--- a/state_machine/applications/flight/Tasks/radio.py
+++ b/state_machine/applications/flight/Tasks/radio.py
@@ -57,7 +57,7 @@ class task(Task):
             cubesat.radio.listen()
             response = await cubesat.radio.receive(keep_listening=True, with_ack=ANTENNA_ATTACHED, timeout=10)
             if response is not None:
-                cubesat.f_deploy = True
+                cubesat.f_contact = True
                 header = response[0]
                 response = response[1:]  # remove the header byte
 

--- a/state_machine/applications/flight/Tasks/safety.py
+++ b/state_machine/applications/flight/Tasks/safety.py
@@ -20,8 +20,8 @@ class task(Task):
             self.debug(f'Temp too high ({temp:.1f}°C >= {cubesat.HIGH_TEMP - 1:.1f}°C)')
         else:
             self.debug_status(vbatt, temp)
-            self.debug('Safe operating conditions reached, switching to normal mode')
-            state_machine.switch_to('Normal')
+            self.debug(f'Safe operating conditions reached, switching back to {state_machine.previous_state} mode')
+            state_machine.switch_to(state_machine.previous_state)
 
     def other_modes(self, vbatt, temp):
         if vbatt < cubesat.LOW_VOLTAGE:

--- a/state_machine/applications/flight/config.py
+++ b/state_machine/applications/flight/config.py
@@ -39,7 +39,6 @@ config = {
         },
         "StepsTo": [
             "Safe",
-            "DeTumble"
         ]
     },
     "Safe": {
@@ -51,7 +50,8 @@ config = {
             }
         },
         "StepsTo": [
-            "Normal"
+            "Normal",
+            "Deployment"
         ],
         "EnterFunctions": [
             "Announcer",
@@ -62,16 +62,29 @@ config = {
             "LowPowerOff"
         ]
     },
-    "DeTumble": {
+    "Deployment": {
         "Tasks": {
+            "Radio": {
+                "Interval": 30.0,
+                "Priority": 3,
+                "ScheduleLater": False
+            },
+            "DeploymentManager": {
+                "Interval": 5.0,
+                "Priority": 1,
+                "ScheduleLater": False
+            },
             "Safety": {
-                "Interval": 15.0,
+                "Interval": 10.0,
                 "Priority": 3,
                 "ScheduleLater": False
             }
         },
         "StepsTo": [
-            "Normal"
+            "Normal",
+            "Safe"
         ]
     }
 }
+
+initial = "Deployment"

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -2,6 +2,7 @@ import time
 import tasko
 
 import lib.reader as reader
+import random
 try:
     from ulab.numpy import array
 except ImportError:
@@ -69,6 +70,7 @@ class Satellite:
         self.c_gs_resp = 1
         self.c_state_err = 0
         self.c_boot = None
+        self.f_deploy = False
 
         # magnetometer and accelerometer chosen to be arbitrary non zero, non parallel values
         # to provide more interesting output from the b-cross controller.
@@ -77,7 +79,10 @@ class Satellite:
         self._gyro = [0.0, 0.0, 0.0]
         self._torque = [0, 0, 0]
         self._cpu_temp = 30
+
+        # debug utilities
         self.sim = False
+        self.randomize_voltage = False
 
     @property
     def acceleration(self):
@@ -118,7 +123,9 @@ class Satellite:
 
     @property
     def battery_voltage(self):
-        return 6.4
+        reader.read(self)
+        random_offset = - 0.5 + random.random() if self.randomize_voltage else 0
+        return self.LOW_VOLTAGE + 0.01 + random_offset
 
     def log(self, str):
         """Logs to sd card"""
@@ -132,10 +139,6 @@ class Satellite:
 
     @property
     def imu(self):
-        return True
-
-    @property
-    def neopixel(self):
         return True
 
     @property

--- a/state_machine/drivers/emulation/lib/reader.py
+++ b/state_machine/drivers/emulation/lib/reader.py
@@ -8,8 +8,16 @@ def read(cubesat):
         data = sys.stdin.readline()
         if len(data) > 3 and data[0:3] == ">>>":
             # print(data)
-            cubesat.sim = True
             if data[3] == 'ω':
+                cubesat.sim = True
                 cubesat._gyro = json.loads(data[4:])
             if data[3] == 'b':
+                cubesat.sim = True
                 cubesat._mag = json.loads(data[4:])
+            if data[3] == 'd':  # debug
+                if data[4] == 'v':  # randomize voltage
+                    cubesat.randomize_voltage = not cubesat.randomize_voltage
+                    if cubesat.randomize_voltage:
+                        print("randomizing voltage")
+                    else:
+                        print("no longer randomizing voltage")

--- a/state_machine/drivers/emulation/lib/reader.py
+++ b/state_machine/drivers/emulation/lib/reader.py
@@ -21,3 +21,6 @@ def read(cubesat):
                         print("randomizing voltage")
                     else:
                         print("no longer randomizing voltage")
+                if data[4] == 'c':  # Toggle contact flag
+                    cubesat.f_contact = not cubesat.f_contact
+                    print(f'Set contact flag to {cubesat.f_contact}')

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -372,7 +372,7 @@ class _Satellite:
              self.sun_yp.lux - self.sun_yn.lux,
              self.sun_zp.lux - self.sun_zn.lux])
 
-    async def burn(self, dutycycle=0, duration=1):
+    async def burn(self, dutycycle=0.5, duration=1):
         """
         Activates the burnwire for a given duration and dutycycle.
 

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -61,9 +61,9 @@ _LOGFAIL = const(5)
 class _Satellite:
     # Define NVM flags
     f_contact = bitFlag(register=_FLAG, bit=1)
-    f_mdeploy = bitFlag(register=_FLAG, bit=2)
-    f_burn1 = bitFlag(register=_FLAG, bit=3)
-    f_burn2 = bitFlag(register=_FLAG, bit=4)
+    f_burn = bitFlag(register=_FLAG, bit=2)
+    f_free1 = bitFlag(register=_FLAG, bit=3)
+    f_free2 = bitFlag(register=_FLAG, bit=4)
 
     # Define NVM counters
     c_boot = multiBitFlag(register=_BOOTCNT, lowest_bit=0, num_bits=8)
@@ -396,7 +396,7 @@ class _Satellite:
             burnwire.duty_cycle = 0
             self.RGB = (0, 0, 0)
 
-            self._deployA = True  # sets deployment variable to true
+            self.f_burn = True
             return True
             # burnwire.deinit()  # deinitialize burnwire
         except Exception as e:

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -60,7 +60,7 @@ _LOGFAIL = const(5)
 
 class _Satellite:
     # Define NVM flags
-    f_deploy = bitFlag(register=_FLAG, bit=1)
+    f_contact = bitFlag(register=_FLAG, bit=1)
     f_mdeploy = bitFlag(register=_FLAG, bit=2)
     f_burn1 = bitFlag(register=_FLAG, bit=3)
     f_burn2 = bitFlag(register=_FLAG, bit=4)

--- a/state_machine/frame/main.py
+++ b/state_machine/frame/main.py
@@ -5,12 +5,13 @@ if '/lib' not in sys.path:
 import traceback
 from pycubed import cubesat
 from state_machine import state_machine
+from config import initial
 
 
 print('Running...')
 try:
     # should run forever
-    state_machine.start('Normal')
+    state_machine.start(initial)
 except Exception as e:
     formated_exception = traceback.format_exception(e, e, e.__traceback__)
     for line in formated_exception:

--- a/state_machine/frame/state_machine.py
+++ b/state_machine/frame/state_machine.py
@@ -54,6 +54,8 @@ class StateMachine:
             raise ValueError(
                 f'You cannot transition from {self.state} to {state_name}')
 
+        self.previous_state = self.state
+
         # execute transition functions
         if self.state != state_name:
             for fn in self.config[self.state]['ExitFunctions']:


### PR DESCRIPTION
- Added ability to toggle randomization of voltage readings (around low bat threshold) for emulation mode via entering ">>>dv"
- Added deployment state
- Added deployment_manager task
  - If contact established transition to normal mode
  - Otherwise activate burnwire for 15 seconds at default duty cycle
- Added initial state to config.py (application level)
- Added previous state to state machine
- Improved safety state to transition back to previous state
- Renamed f_deploy to f_contact
- Added f_contact to emulation
- Added burn function to emulation
- Added ability to toggle emulated contact flag via ">>>dc"
- Set f_contact to True on recieved message