### PR TITLE
Disk buffered message safety

### DIFF
--- a/state_machine/applications/flight/lib/radio_utils/disk_buffered_message.py
+++ b/state_machine/applications/flight/lib/radio_utils/disk_buffered_message.py
@@ -21,6 +21,7 @@ class DiskBufferedMessage(Message):
         self.priority = 1  # fixed so DiskBufferredMessage packets don't interleave
         self.path = path
         self.msg_len = os.stat(path)[6]
+        self.file_err = False
 
     def packet(self):
         """Reads the next chunk of data from sd, and returns this is a packet.
@@ -31,6 +32,9 @@ class DiskBufferedMessage(Message):
                 payload = f.read(self.packet_len)
         except Exception as e:
             print(f'Error reading file {self.path}: {e}')
+            self.file_err = True
+            pkt = bytearray([headers.DEFAULT]) + bytearray("Error reading file", "utf-8")
+            return pkt, True
         pkt = bytearray(len(payload) + 1)
         if self.msg_len <= self.cursor + self.packet_len:  # last packet
             pkt[0] = headers.DISK_BUFFERED_END
@@ -43,7 +47,7 @@ class DiskBufferedMessage(Message):
         return pkt, True
 
     def done(self):
-        return self.msg_len <= self.cursor
+        return (self.msg_len <= self.cursor) or self.file_err
 
     def ack(self):
         self.cursor += self.packet_len


### PR DESCRIPTION
Stops attempting to send a message if the file is no longer found.
This is to prevent the tx queue from getting stuck.