### PR TITLE
Disable devices when power is low

### DIFF
--- a/state_machine/applications/flight/Tasks/safety.py
+++ b/state_machine/applications/flight/Tasks/safety.py
@@ -16,12 +16,14 @@ class task(Task):
         # margins added to prevent jittering between states
         if vbatt < cubesat.LOW_VOLTAGE + 0.1:
             self.debug(f'Voltage too low ({vbatt:.1f}V < {cubesat.LOW_VOLTAGE + 0.1:.1f}V)', log=True)
+            cubesat.enable_low_power()
         elif temp >= cubesat.HIGH_TEMP - 1:
             self.debug(f'Temp too high ({temp:.1f}°C >= {cubesat.HIGH_TEMP - 1:.1f}°C)', log=True)
         else:
             self.debug_status(vbatt, temp)
             self.debug(
                 f'Safe operating conditions reached, switching back to {state_machine.previous_state} mode', log=True)
+            cubesat.disable_low_power()
             state_machine.switch_to(state_machine.previous_state)
 
     def other_modes(self, vbatt, temp):

--- a/state_machine/applications/flight/Tasks/safety.py
+++ b/state_machine/applications/flight/Tasks/safety.py
@@ -16,14 +16,12 @@ class task(Task):
         # margins added to prevent jittering between states
         if vbatt < cubesat.LOW_VOLTAGE + 0.1:
             self.debug(f'Voltage too low ({vbatt:.1f}V < {cubesat.LOW_VOLTAGE + 0.1:.1f}V)', log=True)
-            cubesat.enable_low_power()
         elif temp >= cubesat.HIGH_TEMP - 1:
             self.debug(f'Temp too high ({temp:.1f}°C >= {cubesat.HIGH_TEMP - 1:.1f}°C)', log=True)
         else:
             self.debug_status(vbatt, temp)
             self.debug(
                 f'Safe operating conditions reached, switching back to {state_machine.previous_state} mode', log=True)
-            cubesat.disable_low_power()
             state_machine.switch_to(state_machine.previous_state)
 
     def other_modes(self, vbatt, temp):

--- a/state_machine/applications/flight/TransitionFunctions.py
+++ b/state_machine/applications/flight/TransitionFunctions.py
@@ -4,8 +4,10 @@ def announcer(source, destination, cubesat):
 
 
 def low_power_on(source, destination, cubesat):
-    print('We should be turning off most of the cubesat\'s power hungry devices')
+    print('Turning off power hungry devices')
+    cubesat.enable_low_power()
 
 
 def low_power_off(source, destination, cubesat):
-    print('We should be returning to normal opperations')
+    print('Setting devices back to normal power modes')
+    cubesat.disable_low_power()

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -181,5 +181,13 @@ class _Satellite:
         self.c_downlink = 0
         self.c_logfail = 0
 
+    def enable_low_power(self):
+        """ set all devices into lowest available power modes """
+        pass
+
+    def disable_low_power(self):
+        """ set all devices into normal power modes """
+        pass
+
 
 cubesat = _Satellite()

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -78,10 +78,10 @@ class _Satellite:
     data_cache = {}
 
     # Satellite attributes
-    # Max opperating temp on specsheet for ATSAMD51J19A (Celsius)
     LOW_VOLTAGE = 3.6  # needs to be higher than harvester IC VBAT_OK ON threshold
+    # Max operating temp on specsheet for ATSAMD51J19A (Celsius)
     HIGH_TEMP = 125
-    # Min opperating temp on specsheet for ATSAMD51J19A (Celsius)
+    # Min operating temp on specsheet for ATSAMD51J19A (Celsius)
     LOW_TEMP = -40
 
     def __new__(cls):

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -495,34 +495,60 @@ class _Satellite:
     def enable_low_power(self):
         """ set all devices into lowest available power modes """
         self.burn(0.0, 0)
-        self.drv_x.throttle_volts = None
-        self.drv_y.throttle_volts = None
-        self.drv_z.throttle_volts = None
-        self.imu.accel_powermode = bmx160.BMX160_ACCEL_SUSPEND_MODE
-        self.imu.gyro_powermode = bmx160.BMX160_GYRO_SUSPEND_MODE
-        self.imu.mag_powermode = bmx160.BMX160_MAG_SUSPEND_MODE
-        self.radio.sleep()
+
+        if self.drv_x:
+            self.drv_x.throttle_volts = None
+        if self.drv_y:
+            self.drv_y.throttle_volts = None
+        if self.drv_z:
+            self.drv_z.throttle_volts = None
+
+        if self.imu:
+            self.imu.accel_powermode = bmx160.BMX160_ACCEL_SUSPEND_MODE
+            self.imu.gyro_powermode = bmx160.BMX160_GYRO_SUSPEND_MODE
+            self.imu.mag_powermode = bmx160.BMX160_MAG_SUSPEND_MODE
+
+        if self.radio:
+            self.radio.sleep()
+
         self.RGB = (0, 0, 0)
-        self.sun_xn.enabled = False
-        self.sun_yn.enabled = False
-        self.sun_zn.enabled = False
-        self.sun_xp.enabled = False
-        self.sun_yp.enabled = False
-        self.sun_zp.enabled = False
+
+        if self.sun_xn:
+            self.sun_xn.enabled = False
+        if self.sun_yn:
+            self.sun_yn.enabled = False
+        if self.sun_zn:
+            self.sun_zn.enabled = False
+        if self.sun_xp:
+            self.sun_xp.enabled = False
+        if self.sun_yp:
+            self.sun_yp.enabled = False
+        if self.sun_zp:
+            self.sun_zp.enabled = False
 
     def disable_low_power(self):
         """ set all devices into normal power modes """
         # error occurs if gyro goes into normal mode before mag/accel
-        self.imu.accel_powermode = bmx160.BMX160_ACCEL_NORMAL_MODE
-        self.imu.mag_powermode = bmx160.BMX160_MAG_NORMAL_MODE
-        self.imu.gyro_powermode = bmx160.BMX160_GYRO_NORMAL_MODE
-        self.radio.idle()
-        self.sun_xn.enabled = True
-        self.sun_yn.enabled = True
-        self.sun_zn.enabled = True
-        self.sun_xp.enabled = True
-        self.sun_yp.enabled = True
-        self.sun_zp.enabled = True
+        if self.imu:
+            self.imu.accel_powermode = bmx160.BMX160_ACCEL_NORMAL_MODE
+            self.imu.mag_powermode = bmx160.BMX160_MAG_NORMAL_MODE
+            self.imu.gyro_powermode = bmx160.BMX160_GYRO_NORMAL_MODE
+
+        if self.radio:
+            self.radio.idle()
+
+        if self.sun_xn:
+            self.sun_xn.enabled = True
+        if self.sun_yn:
+            self.sun_yn.enabled = True
+        if self.sun_zn:
+            self.sun_zn.enabled = True
+        if self.sun_xp:
+            self.sun_xp.enabled = True
+        if self.sun_yp:
+            self.sun_yp.enabled = True
+        if self.sun_zp:
+            self.sun_zp.enabled = True
 
 
 # initialize Satellite as cubesat

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -492,6 +492,37 @@ class _Satellite:
         self.c_downlink = 0
         self.c_logfail = 0
 
+    def enable_low_power(self):
+        """ set all devices into lowest available power modes """
+        self.burn(0.0, 0)
+        self.drv_x.throttle_volts = None
+        self.drv_y.throttle_volts = None
+        self.drv_z.throttle_volts = None
+        self.imu.accel_powermode = BMX160_ACCEL_SUSPEND_MODE
+        self.imu.gyro_powermode = BMX160_GYRO_SUSPEND_MODE
+        self.imu.mag_powermode = BMX160_MAG_SUSPEND_MODE
+        self.radio.sleep()
+        self.RGB = (0, 0, 0)
+        self.sun_xn.enabled = False
+        self.sun_yn.enabled = False
+        self.sun_zn.enabled = False
+        self.sun_xp.enabled = False
+        self.sun_yp.enabled = False
+        self.sun_zp.enabled = False
+
+    def disable_low_power(self):
+        """ set all devices into normal power modes """
+        self.imu.accel_powermode = BMX160_ACCEL_NORMAL_MODE
+        self.imu.gyro_powermode = BMX160_GYRO_NORMAL_MODE
+        self.imu.mag_powermode = BMX160_MAG_NORMAL_MODE
+        self.radio.idle()
+        self.sun_xn.enabled = True
+        self.sun_yn.enabled = True
+        self.sun_zn.enabled = True
+        self.sun_xp.enabled = True
+        self.sun_yp.enabled = True
+        self.sun_zp.enabled = True
+
 
 # initialize Satellite as cubesat
 cubesat = _Satellite()

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -512,9 +512,10 @@ class _Satellite:
 
     def disable_low_power(self):
         """ set all devices into normal power modes """
+        # error occurs if gyro goes into normal mode before mag/accel
         self.imu.accel_powermode = bmx160.BMX160_ACCEL_NORMAL_MODE
-        self.imu.gyro_powermode = bmx160.BMX160_GYRO_NORMAL_MODE
         self.imu.mag_powermode = bmx160.BMX160_MAG_NORMAL_MODE
+        self.imu.gyro_powermode = bmx160.BMX160_GYRO_NORMAL_MODE
         self.radio.idle()
         self.sun_xn.enabled = True
         self.sun_yn.enabled = True

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -498,9 +498,9 @@ class _Satellite:
         self.drv_x.throttle_volts = None
         self.drv_y.throttle_volts = None
         self.drv_z.throttle_volts = None
-        self.imu.accel_powermode = BMX160_ACCEL_SUSPEND_MODE
-        self.imu.gyro_powermode = BMX160_GYRO_SUSPEND_MODE
-        self.imu.mag_powermode = BMX160_MAG_SUSPEND_MODE
+        self.imu.accel_powermode = bmx160.BMX160_ACCEL_SUSPEND_MODE
+        self.imu.gyro_powermode = bmx160.BMX160_GYRO_SUSPEND_MODE
+        self.imu.mag_powermode = bmx160.BMX160_MAG_SUSPEND_MODE
         self.radio.sleep()
         self.RGB = (0, 0, 0)
         self.sun_xn.enabled = False
@@ -512,9 +512,9 @@ class _Satellite:
 
     def disable_low_power(self):
         """ set all devices into normal power modes """
-        self.imu.accel_powermode = BMX160_ACCEL_NORMAL_MODE
-        self.imu.gyro_powermode = BMX160_GYRO_NORMAL_MODE
-        self.imu.mag_powermode = BMX160_MAG_NORMAL_MODE
+        self.imu.accel_powermode = bmx160.BMX160_ACCEL_NORMAL_MODE
+        self.imu.gyro_powermode = bmx160.BMX160_GYRO_NORMAL_MODE
+        self.imu.mag_powermode = bmx160.BMX160_MAG_NORMAL_MODE
         self.radio.idle()
         self.sun_xn.enabled = True
         self.sun_yn.enabled = True

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -78,8 +78,8 @@ class _Satellite:
     data_cache = {}
 
     # Satellite attributes
-    LOW_VOLTAGE = 3.0
     # Max opperating temp on specsheet for ATSAMD51J19A (Celsius)
+    LOW_VOLTAGE = 3.6  # needs to be higher than harvester IC VBAT_OK ON threshold
     HIGH_TEMP = 125
     # Min opperating temp on specsheet for ATSAMD51J19A (Celsius)
     LOW_TEMP = -40


### PR DESCRIPTION
- Set the low voltage threshold to 3.6V - this will prevent the harvester chips from disabling the MCU before the mcu turns everything else off
- Create and call functions that set devices into low power and normal power modes
- Resolves #303 