### PR TITLE
use super.debug to print logging error

### DIFF
--- a/state_machine/applications/flight/Tasks/log.py
+++ b/state_machine/applications/flight/Tasks/log.py
@@ -26,7 +26,7 @@ class LogTask(Task):
                 self.log(msg)
             except Exception as e:
                 # shouldn't call self.debug to prevent never ending loop
-                print(f'Error logging to file: {e}')
+                super().debug(f'Error logging to file: {e}', 1)
 
     def log(self, msg):
         """


### PR DESCRIPTION
Not sure if this is a good idea or not - I just saw it and decided creating a PR would be faster than explaining.