### PR TITLE
Add sun data to telemetry and Updates to Emulator Drivers

### DIFF
--- a/state_machine/applications/flight/Tasks/telemetry.py
+++ b/state_machine/applications/flight/Tasks/telemetry.py
@@ -3,7 +3,6 @@
 from Tasks.log import LogTask as Task
 from pycubed import cubesat
 import files
-import time
 import logs
 
 class task(Task):
@@ -24,10 +23,10 @@ class task(Task):
             self.write_beacon()
 
     def write_beacon(self):
-        currTime = time.time()
-        TIMEINTERVAL = 1000
+        t = cubesat.rtc.datetime
+        hour_stamp = f'{t.tm_year}.{t.tm_mon}.{t.tm_mday}.{t.tm_hour}'
         log_directory = "/sd/logs/"
-        current_file = f"{log_directory}beacon/{int(currTime//TIMEINTERVAL)}.txt"
+        current_file = f"{log_directory}beacon/{hour_stamp}.txt"
         beacon_packet = logs.beacon_packet()
         file = open(current_file, "ab+")
         file.write(bytearray(beacon_packet))

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -25,6 +25,12 @@ Define HardwareInitException
 class HardwareInitException(Exception):
     pass
 
+class rtcStruct:
+    def __init__(self, dateInput: time.struct_time):
+        self.datetime = dateInput
+
+    def updateTime(self, dateInput) -> None:
+        self.datetime = dateInput
 
 class _Satellite:
     # Define NVM flags
@@ -68,6 +74,7 @@ class _Satellite:
         self._torque = [0, 0, 0]
         self._cpu_temp = 30
         self._imu_temperature = 20
+        self._lux = array([2.0, 4.0, 7.0])
 
         # debug utilities
         self.sim = False
@@ -92,6 +99,12 @@ class _Satellite:
         """ return the gyroscope reading from the IMU """
         reader.read(self)
         return self._gyro
+
+    @property
+    def lux(self):
+        """return lux value from the sun sensors"""
+        reader.read(self)
+        return self._lux
 
     @property
     def temperature_imu(self):
@@ -138,6 +151,22 @@ class _Satellite:
 
     @property
     def neopixel(self):
+        return True
+
+    @property
+    def rtc(self):
+        return rtcStruct(time.gmtime())
+
+    @property
+    def sun_yn(self):
+        return True
+
+    @property
+    def sun_zn(self):
+        return True
+
+    @property
+    def sun_xn(self):
         return True
 
     async def burn(self, dutycycle=0.5, duration=1):

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -102,15 +102,11 @@ class _Satellite:
         return self._gyro
 
     @property
-    def luxp(self):
-        """return lux value from the sun sensors"""
-        reader.read(self)
-        return self._luxp
-
-    @property
-    def luxn(self):
-        reader.read(self)
-        return self._luxn
+    def sun_vector(self):
+        """returns the sun pointing vector in the body frame"""
+        return array([self._luxp[0] - self._luxn[0],
+                      self._luxp[1] - self._luxn[1],
+                      self._luxp[2] - self._luxn[2]])
 
     @property
     def temperature_imu(self):

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -102,10 +102,15 @@ class _Satellite:
         return self._gyro
 
     @property
-    def lux(self):
+    def luxp(self):
         """return lux value from the sun sensors"""
         reader.read(self)
-        return self._lux
+        return self._luxp
+
+    @property
+    def luxn(self):
+        reader.read(self)
+        return self._luxn
 
     @property
     def temperature_imu(self):

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -102,13 +102,6 @@ class _Satellite:
         return self._gyro
 
     @property
-    def sun_vector(self):
-        """returns the sun pointing vector in the body frame"""
-        return array([self._luxp[0] - self._luxn[0],
-                      self._luxp[1] - self._luxn[1],
-                      self._luxp[2] - self._luxn[2]])
-
-    @property
     def temperature_imu(self):
         """ return the thermometer reading from the IMU """
         reader.read(self)
@@ -141,6 +134,13 @@ class _Satellite:
     @property
     def imu(self):
         return True
+
+    @property
+    def sun_vector(self):
+        """returns the sun pointing vector in the body frame"""
+        return array([self._luxp[0] - self._luxn[0],
+                      self._luxp[1] - self._luxn[1],
+                      self._luxp[2] - self._luxn[2]])
 
     @property
     def micro(self):

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -139,11 +139,6 @@ class _Satellite:
         print(f'log not implemented, tried to log: {str}')
 
     @property
-    def sun_vector(self):
-        """Returns the sun pointing vector in the body frame"""
-        return array([0, 0, 0])
-
-    @property
     def imu(self):
         return True
 

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -25,12 +25,16 @@ Define HardwareInitException
 class HardwareInitException(Exception):
     pass
 
-class rtcStruct:
+class rtc_sensor:
     def __init__(self, dateInput: time.struct_time):
         self.datetime = dateInput
 
-    def updateTime(self, dateInput) -> None:
+    def updateTime(self, dateInput):
         self.datetime = dateInput
+
+class sun_sensor:
+    def __init__(self, lux):
+        self.lux = lux
 
 class _Satellite:
     # Define NVM flags
@@ -74,8 +78,8 @@ class _Satellite:
         self._torque = [0, 0, 0]
         self._cpu_temp = 30
         self._imu_temperature = 20
-        self._luxn = array([2.0, 4.0, 7.0])
         self._luxp = array([3.0, 1.0, 2.0])
+        self._luxn = array([2.0, 4.0, 7.0])
 
         # debug utilities
         self.sim = False
@@ -143,6 +147,14 @@ class _Satellite:
                       self._luxp[2] - self._luxn[2]])
 
     @property
+    def lux_p(self):
+        return array([self._luxp[0], self._luxp[1], self._luxp[2]])
+
+    @property
+    def lux_n(self):
+        return array([self._luxn[0], self._luxn[1], self._luxn[2]])
+
+    @property
     def micro(self):
         return True
 
@@ -152,31 +164,31 @@ class _Satellite:
 
     @property
     def rtc(self):
-        return rtcStruct(time.gmtime())
+        return rtc_sensor(time.gmtime())
 
     @property
     def sun_yn(self):
-        return True
+        return sun_sensor(self._luxn[1])
 
     @property
     def sun_zn(self):
-        return True
+        return sun_sensor(self._luxn[2])
 
     @property
     def sun_xn(self):
-        return True
+        return sun_sensor(self._luxn[0])
 
     @property
     def sun_yp(self):
-        return True
+        return sun_sensor(self._luxp[1])
 
     @property
     def sun_zp(self):
-        return True
+        return sun_sensor(self._luxp[2])
 
     @property
     def sun_xp(self):
-        return True
+        return sun_sensor(self._luxp[0])
 
     async def burn(self, dutycycle=0.5, duration=1):
         """

--- a/state_machine/drivers/emulation/lib/pycubed.py
+++ b/state_machine/drivers/emulation/lib/pycubed.py
@@ -74,7 +74,8 @@ class _Satellite:
         self._torque = [0, 0, 0]
         self._cpu_temp = 30
         self._imu_temperature = 20
-        self._lux = array([2.0, 4.0, 7.0])
+        self._luxn = array([2.0, 4.0, 7.0])
+        self._luxp = array([3.0, 1.0, 2.0])
 
         # debug utilities
         self.sim = False
@@ -167,6 +168,18 @@ class _Satellite:
 
     @property
     def sun_xn(self):
+        return True
+
+    @property
+    def sun_yp(self):
+        return True
+
+    @property
+    def sun_zp(self):
+        return True
+
+    @property
+    def sun_xp(self):
         return True
 
     async def burn(self, dutycycle=0.5, duration=1):

--- a/state_machine/drivers/pycubedmini/lib/pycubed.py
+++ b/state_machine/drivers/pycubedmini/lib/pycubed.py
@@ -424,6 +424,18 @@ class _Satellite:
              self.sun_yp.lux - self.sun_yn.lux,
              self.sun_zp.lux - self.sun_zn.lux])
 
+    @property
+    def lux_p(self):
+        return array([self.sun_xp.lux if self.sun_xp else None,
+                      self.sun_yp.lux if self.sun_yp else None,
+                      self.sun_zp.lux if self.sun_zp else None])
+
+    @property
+    def lux_n(self):
+        return array([self.sun_xn.lux if self.sun_xn else None,
+                      self.sun_yn.lux if self.sun_yn else None,
+                      self.sun_zn.lux if self.sun_zn else None])
+
     async def burn(self, dutycycle=0.5, duration=1):
         """
         Activates the burnwire for a given duration and dutycycle.


### PR DESCRIPTION
Telemetry Task is updated to include the sun_vector data. This includes 3 more floats so it increases the size of the beacon packet to 64 Bytes. It also updates the beacon log filename to be consistent with how the debug log filenames are made. This relies on the rtc, so I will need to update this when changes are finalized for the bug where we cannot log without at rtc. 

Updates the emulator drivers such that we can use rtc and sun sensors. Just added devices as properties and gave sample values for the lux of each sensor stored in an array([x, y, z]) for positive and negative. These values can be retrieved by using the sun_vector property, which subtracts the negative value from the positive value. For the rtc I use a time struct from the time module to get the current time in place of rtc as there is no rtc component in emulation. 