### PR TITLE
Adds sun data to telemetry task

### DIFF
--- a/state_machine/applications/flight/Tasks/telemetry.py
+++ b/state_machine/applications/flight/Tasks/telemetry.py
@@ -3,7 +3,6 @@
 from Tasks.log import LogTask as Task
 from pycubed import cubesat
 import files
-import time
 import logs
 
 class task(Task):
@@ -24,10 +23,10 @@ class task(Task):
             self.write_beacon()
 
     def write_beacon(self):
-        currTime = time.time()
-        TIMEINTERVAL = 1000
+        t = cubesat.rtc.datetime
+        hour_stamp = f'{t.tm_year}.{t.tm_mon}.{t.tm_mday}.{t.tm_hour}'
         log_directory = "/sd/logs/"
-        current_file = f"{log_directory}beacon/{int(currTime//TIMEINTERVAL)}.txt"
+        current_file = f"{log_directory}beacon/{hour_stamp}.txt"
         beacon_packet = logs.beacon_packet()
         file = open(current_file, "ab+")
         file.write(bytearray(beacon_packet))


### PR DESCRIPTION
adds the sun_vector data to the beacon as well as updates the beacon log naming convention to be consistent with the debug logs naming. These changes work with an emulated workspace, however, I am unable to test on hardware if there are modification I need to make please let me know, but I think I modified the emulation drivers such that it is consistent with the pycubedmini driver for retrieving sun data. 

Will be susceptible to the bug that prevents logging with no rtc, but I can modify this to include the changes that are being worked on for that bug when they are finished. 