### PR TITLE
Pq to class

### DIFF
--- a/applications/flight/Tasks/radio.py
+++ b/applications/flight/Tasks/radio.py
@@ -4,7 +4,7 @@ Radio Task:
 Manages all radio communication for the cubesat.
 """
 from Tasks.log import LogTask as Task
-import radio_utils.transmission_queue as tq
+from radio_utils.transmission_queue import transmission_queue as tq
 import radio_utils.commands as cdh
 import radio_utils.headers as headers
 import radio_utils.message as message

--- a/applications/flight/lib/radio_utils/commands.py
+++ b/applications/flight/lib/radio_utils/commands.py
@@ -7,7 +7,7 @@ import time
 import os
 from pycubed import cubesat
 import radio_utils
-from radio_utils import transmission_queue as tq
+from radio_utils.transmission_queue import transmission_queue as tq
 from radio_utils import headers
 from radio_utils.disk_buffered_message import DiskBufferedMessage
 from radio_utils.memory_buffered_message import MemoryBufferedMessage

--- a/applications/flight/lib/radio_utils/priority_queue.py
+++ b/applications/flight/lib/radio_utils/priority_queue.py
@@ -12,94 +12,35 @@ Usage:
 >>> heapify(x)        # transforms list into a heap, in-place, in linear time
 """
 
-__all__ = ['push', 'pop', 'heapify']
-
-def push(heap, item):
-    """Push item onto heap, maintaining the heap invariant.
-
-    :param heap: The heap to push the item onto
-    :type heap: list
-    :param item: Any well ordered item
-    """
-    heap.append(item)
-    _siftdown_max(heap, 0, len(heap) - 1)
-
-def pop(heap):
-    """Pop the largest item off the heap, maintaining the heap invariant.
-
-    :param heap: The heap to pop the item from
-    :type heap: list
-    """
-    lastelt = heap.pop()    # raises appropriate IndexError if heap is empty
-    if heap:
-        returnitem = heap[0]
-        heap[0] = lastelt
-        _siftup_max(heap, 0)
-        return returnitem
-    return lastelt
-
-def heapify(heap):
-    """Transform list into a maxheap, in-place, in O(len(x)) time.
-
-    :param heap: The list to heapify
-    :type heap: list
-    """
-    n = len(heap)
-    for i in reversed(range(n // 2)):
-        _siftup_max(heap, i)
-    return heap
-
-def _siftdown_max(heap, startpos, pos):
-    'Maxheap variant of _siftdown'
-    newitem = heap[pos]
-    # Follow the path to the root, moving parents down until finding a place
-    # newitem fits.
-    while pos > startpos:
-        parentpos = (pos - 1) >> 1
-        parent = heap[parentpos]
-        if parent < newitem:
-            heap[pos] = parent
-            pos = parentpos
-            continue
-        break
-    heap[pos] = newitem
-
-def _siftup_max(heap, pos):
-    'Maxheap variant of _siftup'
-    endpos = len(heap)
-    startpos = pos
-    newitem = heap[pos]
-    # Bubble up the larger child until hitting a leaf.
-    childpos = 2 * pos + 1    # leftmost child position
-    while childpos < endpos:
-        # Set childpos to index of larger child.
-        rightpos = childpos + 1
-        if rightpos < endpos and not heap[rightpos] < heap[childpos]:
-            childpos = rightpos
-        # Move the larger child up.
-        heap[pos] = heap[childpos]
-        pos = childpos
-        childpos = 2 * pos + 1
-    # The leaf at pos is empty now.  Put newitem there, and bubble it up
-    # to its final resting place (by sifting its parents down).
-    heap[pos] = newitem
-    _siftdown_max(heap, startpos, pos)
-
 
 class PriorityQueue:
+    """
+    For this to work the types being stored in the priority queue need to be
+    well-ordered as we use comparison operations. This should be done by storing
+    data belonging to some class which has a self.priority value.
+    """
 
-    def __init__(self) -> None:
-        self.queue = []
+    def __init__(self, queue, limit=1000) -> None:
+        self.queue = queue
+        self.limit = limit
 
-    def push(self, item):
+        n = len(self.queue)
+        for i in reversed(range(n // 2)):
+            self.__siftup_max(i)
+
+    def push(self, item) -> None:
         """Push item onto heap, maintaining the heap invariant.
 
         :param heap: The heap to push the item onto
         :type heap: list
         :param item: Any well ordered item
         """
-        self.queue.append(item)
-        _siftdown_max(0, len(self.queue) - 1)
+        if len(self.queue) < self.limit:
+            self.queue.append(item)
+            self.__siftdown_max(0, len(self.queue) - 1)
+        else:
+            raise Exception("Queue is full")
+
 
     def pop(self):
         """Pop the largest item off the heap, maintaining the heap invariant.
@@ -111,11 +52,11 @@ class PriorityQueue:
         if self.queue:
             returnitem = self.queue[0]
             self.queue[0] = lastelt
-            self._siftup_max(0)
+            self.__siftup_max(0)
             return returnitem
         return lastelt
 
-    def heapify(self):
+    def heapify(self) -> None:
         """Transform list into a maxheap, in-place, in O(len(x)) time.
 
         :param heap: The list to heapify
@@ -123,9 +64,22 @@ class PriorityQueue:
         """
         n = len(self.queue)
         for i in reversed(range(n // 2)):
-            self._siftup_max(i)
+            self.__siftup_max(i)
 
-    def _siftdown_max(self, startpos, pos):
+    def size(self) -> int:
+        return len(self.queue)
+    
+    def peek(self):
+        return self.queue[0]
+    
+    def clear(self) -> None:
+        self.queue = []
+
+    def empty(self) -> bool:
+        return len(self.queue) == 0
+
+    # private methods
+    def __siftdown_max(self, startpos, pos) -> None:
         'Maxheap variant of _siftdown'
         newitem = self.queue[pos]
         # Follow the path to the root, moving parents down until finding a place
@@ -140,7 +94,7 @@ class PriorityQueue:
             break
         self.queue[pos] = newitem
 
-    def _siftup_max(self, pos):
+    def __siftup_max(self, pos) -> None:
         'Maxheap variant of _siftup'
         endpos = len(self.queue)
         startpos = pos
@@ -159,4 +113,11 @@ class PriorityQueue:
         # The leaf at pos is empty now.  Put newitem there, and bubble it up
         # to its final resting place (by sifting its parents down).
         self.queue[pos] = newitem
-        self._siftdown_max(startpos, pos)
+        self.__siftdown_max(startpos, pos)
+
+    def __str__(self) -> str:
+        s = '['
+        for idx, item in enumerate(self.queue):
+            s += f'(idx: {idx}, priority: {item.priority}, {item.contents})'
+        s += ']'
+        return s

--- a/applications/flight/lib/radio_utils/priority_queue.py
+++ b/applications/flight/lib/radio_utils/priority_queue.py
@@ -84,3 +84,79 @@ def _siftup_max(heap, pos):
     # to its final resting place (by sifting its parents down).
     heap[pos] = newitem
     _siftdown_max(heap, startpos, pos)
+
+
+class PriorityQueue:
+
+    def __init__(self) -> None:
+        self.queue = []
+
+    def push(self, item):
+        """Push item onto heap, maintaining the heap invariant.
+
+        :param heap: The heap to push the item onto
+        :type heap: list
+        :param item: Any well ordered item
+        """
+        self.queue.append(item)
+        _siftdown_max(0, len(self.queue) - 1)
+
+    def pop(self):
+        """Pop the largest item off the heap, maintaining the heap invariant.
+
+        :param heap: The heap to pop the item from
+        :type heap: list
+        """
+        lastelt = self.queue.pop()    # raises appropriate IndexError if heap is empty
+        if self.queue:
+            returnitem = self.queue[0]
+            self.queue[0] = lastelt
+            self._siftup_max(0)
+            return returnitem
+        return lastelt
+
+    def heapify(self):
+        """Transform list into a maxheap, in-place, in O(len(x)) time.
+
+        :param heap: The list to heapify
+        :type heap: list
+        """
+        n = len(self.queue)
+        for i in reversed(range(n // 2)):
+            self._siftup_max(i)
+
+    def _siftdown_max(self, startpos, pos):
+        'Maxheap variant of _siftdown'
+        newitem = self.queue[pos]
+        # Follow the path to the root, moving parents down until finding a place
+        # newitem fits.
+        while pos > startpos:
+            parentpos = (pos - 1) >> 1
+            parent = self.queue[parentpos]
+            if parent < newitem:
+                self.queue[pos] = parent
+                pos = parentpos
+                continue
+            break
+        self.queue[pos] = newitem
+
+    def _siftup_max(self, pos):
+        'Maxheap variant of _siftup'
+        endpos = len(self.queue)
+        startpos = pos
+        newitem = self.queue[pos]
+        # Bubble up the larger child until hitting a leaf.
+        childpos = 2 * pos + 1    # leftmost child position
+        while childpos < endpos:
+            # Set childpos to index of larger child.
+            rightpos = childpos + 1
+            if rightpos < endpos and not self.queue[rightpos] < self.queue[childpos]:
+                childpos = rightpos
+            # Move the larger child up.
+            self.queue[pos] = self.queue[childpos]
+            pos = childpos
+            childpos = 2 * pos + 1
+        # The leaf at pos is empty now.  Put newitem there, and bubble it up
+        # to its final resting place (by sifting its parents down).
+        self.queue[pos] = newitem
+        self._siftdown_max(startpos, pos)

--- a/applications/flight/lib/radio_utils/priority_queue.py
+++ b/applications/flight/lib/radio_utils/priority_queue.py
@@ -41,7 +41,6 @@ class PriorityQueue:
         else:
             raise Exception("Queue is full")
 
-
     def pop(self):
         """Pop the largest item off the heap, maintaining the heap invariant.
 
@@ -68,10 +67,10 @@ class PriorityQueue:
 
     def size(self) -> int:
         return len(self.queue)
-    
+
     def peek(self):
         return self.queue[0]
-    
+
     def clear(self) -> None:
         self.queue = []
 

--- a/applications/flight/lib/radio_utils/priority_queue.py
+++ b/applications/flight/lib/radio_utils/priority_queue.py
@@ -9,7 +9,7 @@ Usage:
 >>> heap.push(item)                 # pushes a new item on the heap if under limit
 >>> item = heap.pop()               # pops the largest item from the heap
 >>> item = heap.peek()              # largest item on the heap without popping it
->>> heap.heapifu()                  # transforms list into a heap, in-place, in linear time
+>>> heap.heapify()                  # transforms list into a heap, in-place, in linear time
 
 All Items used in this should have a priority property for comparison
 """

--- a/applications/flight/lib/radio_utils/priority_queue.py
+++ b/applications/flight/lib/radio_utils/priority_queue.py
@@ -5,11 +5,13 @@
 
 Usage:
 
->>> heap = []         # creates an empty heap
->>> push(heap, item)  # pushes a new item on the heap
->>> item = pop(heap)  # pops the largest item from the heap
->>> item = heap[0]    # largest item on the heap without popping it
->>> heapify(x)        # transforms list into a heap, in-place, in linear time
+>>> heap = PriorityQueue([], 100)   # creates an empty heap with limit 100
+>>> heap.push(item)                 # pushes a new item on the heap if under limit
+>>> item = heap.pop()               # pops the largest item from the heap
+>>> item = heap.peek()              # largest item on the heap without popping it
+>>> heap.heapifu()                  # transforms list into a heap, in-place, in linear time
+
+All Items used in this should have a priority property for comparison
 """
 
 
@@ -117,6 +119,6 @@ class PriorityQueue:
     def __str__(self) -> str:
         s = '['
         for idx, item in enumerate(self.queue):
-            s += f'(idx: {idx}, priority: {item.priority}, {item.contents})'
+            s += f'(idx: {idx}, priority: {item.priority}, {item})'
         s += ']'
         return s

--- a/applications/flight/lib/radio_utils/transmission_queue.py
+++ b/applications/flight/lib/radio_utils/transmission_queue.py
@@ -3,48 +3,7 @@
 Messages must support the `__lt__`, `__le__`, `__eq__`, `__ge__`, and `__gt__` operators.
 This enables to the max heap to compare messages based on their priority.
 """
-from . import priority_queue as pq
+# from . import priority_queue as pq
+from .priority_queue import PriorityQueue
 
-queue = []
-limit = 100
-
-def push(msg):
-    """Push a msg into the transmission queue
-
-    :param msg: The message to push
-    :type msg: Message | MemoryBufferedMessage | DiskBufferedMessage
-    """
-    if len(queue) < limit:
-        pq.push(queue, msg)
-    else:
-        raise Exception("Queue is full")
-
-def peek():
-    """Returns the next message to be transmitted
-
-    :return: The next message to be transmitted
-    :rtype: Message | MemoryBufferedMessage | DiskBufferedMessage
-    """
-    return queue[0]
-
-def pop():
-    """Returns the next message to be transmitted and removes it from the transmission queue
-
-    :return: The next message to be transmitted
-    :rtype: Message | MemoryBufferedMessage | DiskBufferedMessage
-    """
-    return pq.pop(queue)
-
-def empty():
-    """Returns if the transmission queue is empty"""
-    return len(queue) == 0
-
-def clear():
-    """Clears the transmission queue"""
-    global queue
-    queue = []
-
-def size():
-    """Returns the number of messages in the transmission queue"""
-    global queue
-    return len(queue)
+transmission_queue = PriorityQueue([], 100)

--- a/unit_tests/test_commands.py
+++ b/unit_tests/test_commands.py
@@ -12,7 +12,7 @@ import Tasks.radio as radio
 import radio_utils.commands as cdh
 from state_machine import state_machine
 from testutils import send_cmd
-from radio_utils import transmission_queue as tq
+from radio_utils.transmission_queue import transmission_queue as tq
 from radio_utils import message
 from pycubed import cubesat
 import settings

--- a/unit_tests/test_priority_queue.py
+++ b/unit_tests/test_priority_queue.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, 'applications/flight/lib/radio_utils')
 
-import priority_queue as pq  # noqa: E402
+from priority_queue import PriorityQueue  # noqa: E402
 from message import Message as msg  # noqa: E402
 
 # https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/
@@ -30,52 +30,52 @@ def isHeap(arr):
 class Tests(unittest.TestCase):
 
     def test_heapify(self):
-        h1 = [3, 8, 17, 4]
-        self.assertTrue(isHeap(pq.heapify(h1)))
-        self.assertTrue(isHeap(h1))
-        h2 = [3, 8, 17, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16]
-        self.assertTrue(isHeap(pq.heapify(h2)))
-        self.assertTrue(isHeap(h2))
-        h3 = [4, 3, -3, 0, -1, -2, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16]
-        self.assertTrue(isHeap(pq.heapify(h3)))
-        self.assertTrue(isHeap(h3))
-        h4 = []
-        self.assertTrue(isHeap(pq.heapify(h4)))
-        self.assertTrue(isHeap(h4))
-        h5 = [1, 0, -5, 7, 12, 8, -12]
-        self.assertTrue(isHeap(pq.heapify(h5)))
-        self.assertTrue(isHeap(h5))
+        h1 = PriorityQueue([3, 8, 17, 4])
+        # self.assertTrue(isHeap(pq.heapify(h1)))
+        self.assertTrue(isHeap(h1.queue))
+        h2 = PriorityQueue([3, 8, 17, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16])
+        # self.assertTrue(isHeap(pq.heapify(h2)))
+        self.assertTrue(isHeap(h2.queue))
+        h3 = PriorityQueue([4, 3, -3, 0, -1, -2, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16])
+        # self.assertTrue(isHeap(pq.heapify(h3)))
+        self.assertTrue(isHeap(h3.queue))
+        h4 = PriorityQueue([])
+        # self.assertTrue(isHeap(pq.heapify(h4)))
+        self.assertTrue(isHeap(h4.queue))
+        h5 = PriorityQueue([1, 0, -5, 7, 12, 8, -12])
+        # self.assertTrue(isHeap(pq.heapify(h5)))
+        self.assertTrue(isHeap(h5.queue))
         a = msg(3, 'hello')
         b = msg(3, 'hello')
         c = msg(3, 'hello')
         d = msg(3, 'hello')
-        h6 = [a, c, d]
-        self.assertTrue(isHeap(pq.heapify(h6)))
-        self.assertTrue(isHeap(h6))
-        h7 = [a, b, c, d]
-        self.assertTrue(isHeap(pq.heapify(h7)))
-        self.assertTrue(isHeap(h7))
-        h8 = [d, a, b]
-        self.assertTrue(isHeap(pq.heapify(h8)))
-        self.assertTrue(isHeap(h8))
-        h9 = [d]
-        self.assertTrue(isHeap(pq.heapify(h9)))
-        self.assertTrue(isHeap(h9))
+        h6 = PriorityQueue([a, c, d])
+        # self.assertTrue(isHeap(pq.heapify(h6)))
+        self.assertTrue(isHeap(h6.queue))
+        h7 = PriorityQueue([a, b, c, d])
+        # self.assertTrue(isHeap(pq.heapify(h7)))
+        self.assertTrue(isHeap(h7.queue))
+        h8 = PriorityQueue([d, a, b])
+        # self.assertTrue(isHeap(pq.heapify(h8)))
+        self.assertTrue(isHeap(h8.queue))
+        h9 = PriorityQueue([d])
+        # self.assertTrue(isHeap(pq.heapify(h9)))
+        self.assertTrue(isHeap(h9.queue))
 
     def test_push_and_pop(self):
-        h = []
-        pq.push(h, 3)
-        self.assertEqual(3, h[0])
-        pq.push(h, 8)
-        self.assertEqual(8, h[0])
-        pq.push(h, 0)
-        self.assertEqual(pq.pop(h), 8)
-        self.assertEqual(3, h[0])
-        pq.push(h, 5)
-        self.assertEqual(5, h[0])
-        pq.push(h, 4)
-        self.assertEqual(5, h[0])
-        self.assertEqual(5, pq.pop(h))
-        self.assertEqual(4, pq.pop(h))
-        self.assertEqual(3, pq.pop(h))
-        self.assertEqual(0, pq.pop(h))
+        h = PriorityQueue([])
+        h.push(3)
+        self.assertEqual(3, h.peek())
+        h.push(8)
+        self.assertEqual(8, h.peek())
+        h.push(0)
+        self.assertEqual(h.pop(), 8)
+        self.assertEqual(3, h.peek())
+        h.push(5)
+        self.assertEqual(5, h.peek())
+        h.push(4)
+        self.assertEqual(5, h.peek())
+        self.assertEqual(5, h.pop())
+        self.assertEqual(4, h.pop())
+        self.assertEqual(3, h.pop())
+        self.assertEqual(0, h.pop())

--- a/unit_tests/test_transmission_queue.py
+++ b/unit_tests/test_transmission_queue.py
@@ -2,8 +2,9 @@ import unittest
 import sys
 
 sys.path.insert(0, 'applications/flight/lib')
+sys.path.insert(1, 'applications/flight/lib/radio_utils')
 
-from radio_utils import transmission_queue as tq  # noqa: E402
+from radio_utils.transmission_queue import transmission_queue as tq  # noqa: E402
 
 class Test(unittest.TestCase):
 


### PR DESCRIPTION
Update the priority queue to be a class. Simplifies creating new queues later for image transmission. Closes #390.